### PR TITLE
English improvements

### DIFF
--- a/src/main/resources/assets/bedrockify/lang/en_us.json
+++ b/src/main/resources/assets/bedrockify/lang/en_us.json
@@ -39,7 +39,7 @@
   "bedrockify.options.showSavingOverlay": "Show Saving Overlay:",
   "bedrockify.options.eatingAnimations": "Third Person Eating Animations:",
   "bedrockify.options.pickupAnimations": "Item Pick-Up Animations:",
-  "bedrockify.options.pickupAnimations.tooltip": "Enables the Bedrock-Edition Item Pickup Animations on the Item Hotbar.",
+  "bedrockify.options.pickupAnimations.tooltip": "Enables the Bedrock Item Pickup Animations on the Item Hotbar.",
   "bedrockify.loadingTips.0": "You can change the look of your character changing the current skin under the tap \"Skins\" in the Minecraft Launcher.",
   "bedrockify.loadingTips.1": "Iron golems will fight for you!",
   "bedrockify.loadingTips.2": "Alter the brightness setting to make the game brighter or darker.",

--- a/src/main/resources/assets/bedrockify/lang/en_us.json
+++ b/src/main/resources/assets/bedrockify/lang/en_us.json
@@ -31,7 +31,7 @@
   "bedrockify.options.chatStyle.vanilla": "Java",
   "bedrockify.options.tooltips": "Item Tooltips:",
   "bedrockify.options.rotationalBackground": "Panorama Background On All Screens:",
-  "bedrockify.options.rotationalBackground.tooltip": "EXPERIMETAL: Enables the title screen rotatory background on all screens. Might visually break other mod's settings screens.",
+  "bedrockify.options.rotationalBackground.tooltip": "EXPERIMENTAL: Enables the title screen rotatory background on all screens. Might visually break other mod's settings screens.",
   "bedrockify.options.inventoryHighlight": "Inventory Item Slot Highlight:",
   "bedrockify.options.idleAnimation": "Idle Hand Animation Speed:",
   "bedrockify.options.showBedrockIfyButton": "Show BedrockIfy Settings Button:",

--- a/src/main/resources/assets/bedrockify/lang/en_us.json
+++ b/src/main/resources/assets/bedrockify/lang/en_us.json
@@ -1,6 +1,6 @@
 {
   "bedrockify.hud.position": "Position:",
-  "bedrockify.hud.fps": "Fps:",
+  "bedrockify.hud.fps": "FPS:",
   "bedrockify.options.on": "On",
   "bedrockify.options.off": "Off",
   "bedrockify.options.withPosition": "With Position",
@@ -28,7 +28,7 @@
   "bedrockify.options.reachAround.recipes.tooltip": "Must re-open world to apply changes.",
   "bedrockify.options.chatStyle": "Chat Style:",
   "bedrockify.options.chatStyle.bedrock": "Bedrock",
-  "bedrockify.options.chatStyle.vanilla": "Vanilla",
+  "bedrockify.options.chatStyle.vanilla": "Java",
   "bedrockify.options.tooltips": "Item Tooltips:",
   "bedrockify.options.rotationalBackground": "Panorama Background On All Screens:",
   "bedrockify.options.rotationalBackground.tooltip": "EXPERIMETAL: Enables the title screen rotatory background on all screens. Might visually break other mod's settings screens.",


### PR DESCRIPTION
If you compare Bedrock and Java, you should mention "Java", as Bedrock can be "Vanilla" too.