### PR TITLE
Fix invalid license by adding GPL exception

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -672,3 +672,22 @@ may consider it more useful to permit linking proprietary applications with
 the library.  If this is what you want to do, use the GNU Lesser General
 Public License instead of this License.  But first, please read
 <https://www.gnu.org/licenses/why-not-lgpl.html>.
+
+                "MINECRAFT" LINKING EXCEPTION TO THE GPL
+
+Linking this mod statically or dynamically with other modules is making a
+combined work based on this mod. Thus, the terms and conditions of the GNU
+General Public License cover the whole combination.
+
+In addition, as a special exception, the copyright holders of this mod give you
+permission to combine this mod with free software programs or libraries that
+are released under the GNU LGPL and with code included in the standard release
+of Minecraft under All Rights Reserved (or modified versions of such code, with
+unchanged license). You may copy and distribute such a system following the
+terms of the GNU GPL for this mod and the licenses of the other code concerned.
+
+Note that people who make modified versions of this mod are not obligated to
+grant this special exception for their modified versions; it is their choice
+whether to do so. The GNU General Public License gives permission to release a
+modified version without this exception; this exception also makes it possible
+to release a modified version which carries forward this exception.


### PR DESCRIPTION
Without a Minecraft exception, the license of this mod is effectively All Rights Reserved. This exception must be included for it to be valid.