### PR TITLE
Fixed Position text and fill after overlayIgnoresSafeArea option added

### DIFF
--- a/src/main/java/me/juancarloscp52/bedrockify/client/gui/Overlay.java
+++ b/src/main/java/me/juancarloscp52/bedrockify/client/gui/Overlay.java
@@ -63,8 +63,8 @@ public class Overlay {
         if(settings.getFPSHUDoption()==1)
             position.append(" ").append(fps);
         int positionWidth = client.textRenderer.getWidth(position);
-        fill(matrixStack, textPosX + screenBorder, posY - 2 + screenBorder, textPosX + positionWidth + 6 + screenBorder, posY + 10 + screenBorder, MathHelper.ceil((255.0D * client.options.textBackgroundOpacity))<<24);
-        client.textRenderer.drawWithShadow(matrixStack, position, textPosX + 3 + screenBorder, posY + 1 + screenBorder, 16777215);
+        fill(matrixStack, textPosX + screenBorder, posY + screenBorder, textPosX + positionWidth + 6 + screenBorder, posY + 12 + screenBorder, MathHelper.ceil((255.0D * client.options.textBackgroundOpacity))<<24);
+        client.textRenderer.drawWithShadow(matrixStack, position, textPosX + 3 + screenBorder, posY + 3 + screenBorder, 16777215);
     }
 
     private void renderFpsText(MatrixStack matrixStack) {


### PR DESCRIPTION
Fixed Position position & Fill size; Worked fine with overlayIgnoresSafeArea enabled, but disabled the fill was too tall (off the screen) and the vertical position was too high