### PR TITLE
[fix] prevent warnings by render thread

### DIFF
--- a/src/main/java/me/juancarloscp52/bedrockify/mixin/client/features/panoramaBackground/EntryListWidgetMixin.java
+++ b/src/main/java/me/juancarloscp52/bedrockify/mixin/client/features/panoramaBackground/EntryListWidgetMixin.java
@@ -3,13 +3,11 @@ package me.juancarloscp52.bedrockify.mixin.client.features.panoramaBackground;
 import me.juancarloscp52.bedrockify.Bedrockify;
 import me.juancarloscp52.bedrockify.client.features.panoramaBackground.BedrockifyRotatingCubeMapRenderer;
 import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.gl.VertexBuffer;
 import net.minecraft.client.gui.DrawableHelper;
 import net.minecraft.client.gui.screen.pack.PackScreen;
 import net.minecraft.client.gui.widget.EntryListWidget;
-import net.minecraft.client.render.BufferRenderer;
-import net.minecraft.client.render.Tessellator;
 import net.minecraft.client.util.math.MatrixStack;
+import org.objectweb.asm.Opcodes;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -37,15 +35,9 @@ public abstract class EntryListWidgetMixin {
     }
 
     // Prevent the screen background from drawing
-    @Redirect(method = "render", at=@At(value = "INVOKE",target = "Lnet/minecraft/client/render/Tessellator;draw()V", ordinal = 0))
-    private void doNotDrawBackground(Tessellator tessellator){
-        if(!Bedrockify.getInstance().settings.isCubemapBackgroundEnabled() || shouldIgnoreScreen()){
-            tessellator.draw();
-            return;
-        }
-        tessellator.getBuffer().end();
-//        tessellator.getBuffer().clear();
-        tessellator.getBuffer().clear();
+    @Redirect(method = "render", at=@At(value = "FIELD",target = "Lnet/minecraft/client/gui/widget/EntryListWidget;renderBackground:Z", opcode = Opcodes.GETFIELD))
+    private boolean doNotDrawBackground(EntryListWidget entryListWidget){
+        return !Bedrockify.getInstance().settings.isCubemapBackgroundEnabled() || shouldIgnoreScreen();
     }
 
     private boolean shouldIgnoreScreen() {
@@ -55,26 +47,8 @@ public abstract class EntryListWidgetMixin {
     }
 
     //Prevent top and bottom bars from drawing (Only on pack Screens)
-    @Redirect(method = "render", at=@At(value = "INVOKE",target = "Lnet/minecraft/client/render/Tessellator;draw()V", ordinal = 1))
-    private void doNotDrawBars(Tessellator tessellator){
-        if(this.client.currentScreen instanceof PackScreen && Bedrockify.getInstance().settings.isCubemapBackgroundEnabled()){
-            tessellator.getBuffer().end();
-//            tessellator.getBuffer().clear();
-            tessellator.getBuffer().clear();
-            return;
-        }
-        tessellator.draw();
-    }
-
-    //Prevent top and bottom shadows from drawing (Only on pack Screens)
-    @Redirect(method = "render", at=@At(value = "INVOKE",target = "Lnet/minecraft/client/render/Tessellator;draw()V", ordinal = 2))
-    private void doNotDrawBarsShadows(Tessellator tessellator){
-        if(this.client.currentScreen instanceof PackScreen && Bedrockify.getInstance().settings.isCubemapBackgroundEnabled()){
-            tessellator.getBuffer().end();
-//            tessellator.getBuffer().clear();
-            tessellator.getBuffer().clear();
-            return;
-        }
-        tessellator.draw();
+    @Redirect(method = "render", at=@At(value = "FIELD",target = "Lnet/minecraft/client/gui/widget/EntryListWidget;renderHorizontalShadows:Z", opcode = Opcodes.GETFIELD))
+    private boolean doNotDrawBars(EntryListWidget entryListWidget){
+        return !(this.client.currentScreen instanceof PackScreen) || !Bedrockify.getInstance().settings.isCubemapBackgroundEnabled();
     }
 }


### PR DESCRIPTION
fixes #161

* use `Opcodes.GETFIELD` instead of `BufferBuilder#clear()`