### PR TITLE
[fix][compat] iris shaders

### DIFF
--- a/src/main/java/me/juancarloscp52/bedrockify/mixin/client/features/panoramaBackground/EntryListWidgetMixin.java
+++ b/src/main/java/me/juancarloscp52/bedrockify/mixin/client/features/panoramaBackground/EntryListWidgetMixin.java
@@ -7,7 +7,6 @@ import net.minecraft.client.gui.DrawableHelper;
 import net.minecraft.client.gui.screen.pack.PackScreen;
 import net.minecraft.client.gui.widget.EntryListWidget;
 import net.minecraft.client.util.math.MatrixStack;
-import org.objectweb.asm.Opcodes;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -22,6 +21,8 @@ public abstract class EntryListWidgetMixin {
     @Shadow protected int bottom;
     @Shadow protected int top;
     @Shadow protected abstract void renderBackground(MatrixStack matrices);
+    @Shadow public abstract void setRenderBackground(boolean renderBackground);
+    @Shadow public abstract void setRenderHorizontalShadows(boolean renderHorizontalShadows);
 
     @Redirect(method = "render", at=@At(value = "INVOKE", target = "Lnet/minecraft/client/gui/widget/EntryListWidget;renderBackground(Lnet/minecraft/client/util/math/MatrixStack;)V"))
     private void renderPanorama(EntryListWidget entryListWidget, MatrixStack matrices){
@@ -36,14 +37,12 @@ public abstract class EntryListWidgetMixin {
         }
     }
 
-    @Inject(method = "<init>(Lnet/minecraft/client/MinecraftClient;IIIII)V", at=@At("TAIL"))
+    @Inject(method = "<init>(Lnet/minecraft/client/MinecraftClient;IIIII)V", at=@At("RETURN"))
     private void bedrockify$ctor(MinecraftClient client, int width, int height, int top, int bottom, int itemHeight, CallbackInfo ci){
-        var $this = (EntryListWidget)(Object)this;
-
         // Prevent the screen background from drawing
-        $this.setRenderBackground(!Bedrockify.getInstance().settings.isCubemapBackgroundEnabled() || shouldIgnoreScreen());
+        this.setRenderBackground(!Bedrockify.getInstance().settings.isCubemapBackgroundEnabled() || shouldIgnoreScreen());
         // Prevent top and bottom bars from drawing (Only on pack Screens)
-        $this.setRenderHorizontalShadows(!(this.client.currentScreen instanceof PackScreen) || !Bedrockify.getInstance().settings.isCubemapBackgroundEnabled());
+        this.setRenderHorizontalShadows(!(this.client.currentScreen instanceof PackScreen) || !Bedrockify.getInstance().settings.isCubemapBackgroundEnabled());
     }
 
     private boolean shouldIgnoreScreen() {


### PR DESCRIPTION
fixes #172 

Use the constructor to set fields `renderBackground` and `renderHorizontalShadows` that they can be changed by other MOD. Please check the changes below:

* `EntryListWidgetMixin.java`
  - methods `doNotDrawBackground(EntryListWidget)` and `doNotDrawBars(EntryListWidget)` were removed
  - new method `bedrockify$ctor` was added which targeted to constructor of `EntryListWidget`