### PR TITLE
Fixed Panorama ignore list

### DIFF
--- a/src/main/java/me/juancarloscp52/bedrockify/BedrockifySettings.java
+++ b/src/main/java/me/juancarloscp52/bedrockify/BedrockifySettings.java
@@ -3,18 +3,21 @@ package me.juancarloscp52.bedrockify;
 import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.gui.screen.multiplayer.SocialInteractionsScreen;
+import net.minecraft.client.gui.screen.pack.PackScreen;
 
 import java.util.Arrays;
 import java.util.List;
 
 public class BedrockifySettings {
 
-    public final static List<String> PANORAMA_IGNORED_SCREENS = Arrays.asList(".modmenu.gui.ModsScreen",".iris.gui.", ".modmanager.gui.","net.minecraft.class_5522", "yacl.gui.YACLScreen");
+    private final static List<Class<? extends Screen>> MINECRAFT_IGNORED_SCREENS = Arrays.asList(PackScreen.class, SocialInteractionsScreen.class);
+    public final static List<String> PANORAMA_IGNORED_SCREENS = Arrays.asList(".modmenu.gui.ModsScreen", ".iris.gui.", ".modmanager.gui.", "yacl.gui.YACLScreen");
     public boolean loadingScreen = true;
     public boolean bedrockIfyButton = true;
     public boolean showPositionHUD = true;
     public byte FPSHUD = 0;
-    public byte heldItemTooltip=2;
+    public byte heldItemTooltip = 2;
     public boolean showPaperDoll = true;
     public boolean showChunkMap = false;
     public boolean reacharound = true;
@@ -25,7 +28,7 @@ public class BedrockifySettings {
     public int screenSafeArea = 0;
     public boolean overlayIgnoresSafeArea = false;
     public boolean cubeMapBackground = true;
-    public boolean bedrockChat=true;
+    public boolean bedrockChat = true;
     public boolean slotHighlight = true;
     public int highLightColor1 = (255 << 8) + (255) + (255 << 16) + (255 << 24);
     public int highLightColor2 = 64 + (170 << 8) + (109 << 16) + (255 << 24);
@@ -48,11 +51,15 @@ public class BedrockifySettings {
 
     public List<String> panoramaIgnoredScreens = PANORAMA_IGNORED_SCREENS;
 
-    public boolean panoramaIgnoreScreen(Screen screen){
-        if(null != screen){
+    public boolean panoramaIgnoreScreen(Screen screen) {
+        if (screen != null) {
+            // Checks if the screen is a Minecraft screen that would break in any case
+            if (MINECRAFT_IGNORED_SCREENS.contains(screen.getClass()))
+                return true;
+
             // Check If screen is in ignore list.
-            for(String screenName : panoramaIgnoredScreens){
-                if(screen.getClass().getName().contains(screenName.trim()))
+            for (String screenName : panoramaIgnoredScreens) {
+                if (screen.getClass().getName().contains(screenName.trim()))
                     return true;
             }
             // check for language reload screen.
@@ -61,19 +68,19 @@ public class BedrockifySettings {
         return false;
     }
 
-    public boolean isSneakingShieldEnabled(){
+    public boolean isSneakingShieldEnabled() {
         return this.sneakingShield;
     }
 
-    public boolean isDyingTreesEnabled(){
+    public boolean isDyingTreesEnabled() {
         return this.dyingTrees;
     }
 
-    public boolean isBiggerIconsEnabled(){
+    public boolean isBiggerIconsEnabled() {
         return biggerIcons;
     }
 
-    public boolean isQuickArmorSwapEnabled(){
+    public boolean isQuickArmorSwapEnabled() {
         return quickArmorSwap;
     }
 
@@ -84,32 +91,37 @@ public class BedrockifySettings {
     public boolean isEatingAnimationsEnabled() {
         return eatingAnimations;
     }
-    public boolean isPickupAnimationsEnabled(){
+
+    public boolean isPickupAnimationsEnabled() {
         return pickupAnimations;
     }
+
     public boolean isCubemapBackgroundEnabled() {
         return cubeMapBackground;
     }
-    public boolean isLoadingScreenEnabled(){
+
+    public boolean isLoadingScreenEnabled() {
         return loadingScreen;
     }
+
     public boolean isShowPositionHUDEnabled() {
         return showPositionHUD && !MinecraftClient.getInstance().hasReducedDebugInfo();
     }
+
     public boolean isExpTextStyle() {
         return expTextStyle;
     }
 
 
-    public int getHighLightColor1(){
+    public int getHighLightColor1() {
         return this.highLightColor1;
     }
 
-    public int getHighLightColor2(){
+    public int getHighLightColor2() {
         return this.highLightColor2;
     }
 
-    public byte getHeldItemTooltip(){
+    public byte getHeldItemTooltip() {
         return this.heldItemTooltip;
     }
 
@@ -117,11 +129,11 @@ public class BedrockifySettings {
         return FPSHUD;
     }
 
-    public double getReacharoundBlockDistance(){
+    public double getReacharoundBlockDistance() {
         return reacharoundBlockDistance;
     }
 
-    public int getReacharoundPitchAngle(){
+    public int getReacharoundPitchAngle() {
         return reacharoundPitchAngle;
     }
 
@@ -166,7 +178,7 @@ public class BedrockifySettings {
         return screenSafeArea;
     }
 
-    public float getIdleAnimation(){
+    public float getIdleAnimation() {
         return idleAnimation;
     }
 

--- a/src/main/java/me/juancarloscp52/bedrockify/mixin/client/features/panoramaBackground/EntryListWidgetMixin.java
+++ b/src/main/java/me/juancarloscp52/bedrockify/mixin/client/features/panoramaBackground/EntryListWidgetMixin.java
@@ -17,28 +17,36 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(EntryListWidget.class)
 public abstract class EntryListWidgetMixin {
-    @Shadow @Final protected MinecraftClient client;
-    @Shadow protected int bottom;
-    @Shadow protected int top;
-    @Shadow protected abstract void renderBackground(MatrixStack matrices);
-    @Shadow public abstract void setRenderBackground(boolean renderBackground);
-    @Shadow public abstract void setRenderHorizontalShadows(boolean renderHorizontalShadows);
+    @Shadow
+    @Final
+    protected MinecraftClient client;
+    @Shadow
+    protected int bottom;
+    @Shadow
+    protected int top;
 
-    @Redirect(method = "render", at=@At(value = "INVOKE", target = "Lnet/minecraft/client/gui/widget/EntryListWidget;renderBackground(Lnet/minecraft/client/util/math/MatrixStack;)V"))
-    private void renderPanorama(EntryListWidget entryListWidget, MatrixStack matrices){
-        if(!Bedrockify.getInstance().settings.isCubemapBackgroundEnabled() || shouldIgnoreScreen() /*|| this.client.currentScreen.getClass().getName().equals("net.minecraft.class_5522")*/) {
+    @Shadow
+    protected abstract void renderBackground(MatrixStack matrices);
+
+    @Shadow
+    public abstract void setRenderBackground(boolean renderBackground);
+
+    @Shadow
+    public abstract void setRenderHorizontalShadows(boolean renderHorizontalShadows);
+
+    @Redirect(method = "render", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/widget/EntryListWidget;renderBackground(Lnet/minecraft/client/util/math/MatrixStack;)V"))
+    private void renderPanorama(EntryListWidget entryListWidget, MatrixStack matrices) {
+        if (!Bedrockify.getInstance().settings.isCubemapBackgroundEnabled() || shouldIgnoreScreen() /*|| this.client.currentScreen.getClass().getName().equals("net.minecraft.class_5522")*/) {
             this.renderBackground(matrices);
             return;
         }
 
-        if (!(this.client.currentScreen instanceof PackScreen)) {
-            BedrockifyRotatingCubeMapRenderer.getInstance().render();
-            DrawableHelper.fill(matrices, 0, this.top, client.getWindow().getScaledWidth(), this.bottom, (100 << 24));
-        }
+        BedrockifyRotatingCubeMapRenderer.getInstance().render();
+        DrawableHelper.fill(matrices, 0, this.top, client.getWindow().getScaledWidth(), this.bottom, (100 << 24));
     }
 
-    @Inject(method = "<init>(Lnet/minecraft/client/MinecraftClient;IIIII)V", at=@At("RETURN"))
-    private void bedrockify$ctor(MinecraftClient client, int width, int height, int top, int bottom, int itemHeight, CallbackInfo ci){
+    @Inject(method = "<init>(Lnet/minecraft/client/MinecraftClient;IIIII)V", at = @At("RETURN"))
+    private void bedrockify$ctor(MinecraftClient client, int width, int height, int top, int bottom, int itemHeight, CallbackInfo ci) {
         // Prevent the screen background from drawing
         this.setRenderBackground(!Bedrockify.getInstance().settings.isCubemapBackgroundEnabled() || shouldIgnoreScreen());
         // Prevent top and bottom bars from drawing (Only on pack Screens)


### PR DESCRIPTION
This pull request creates a separate internal list with direct classes for all Minecraft screens in which the panorama background should not be rendered, for one thing it is easier to port, and for another the social interactions screen was broken if you installed Bedrockify in your IDEA as a mod. 