### PR TITLE
[refactor] reacharound placement feature

### DIFF
--- a/src/main/java/me/juancarloscp52/bedrockify/client/features/reacharoundPlacement/ReachAroundPlacement.java
+++ b/src/main/java/me/juancarloscp52/bedrockify/client/features/reacharoundPlacement/ReachAroundPlacement.java
@@ -5,8 +5,10 @@ import net.minecraft.block.*;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.network.ClientPlayerEntity;
 import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.entity.Entity;
 import net.minecraft.util.hit.HitResult;
 import net.minecraft.util.math.BlockPos;
+import org.jetbrains.annotations.NotNull;
 
 import static net.minecraft.client.gui.DrawableHelper.fill;
 
@@ -27,8 +29,17 @@ public class ReachAroundPlacement {
         if (client.player == null || client.world == null || client.crosshairTarget == null)
             return false;
         final ClientPlayerEntity player = client.player;
-        final BlockPos facingSteppingBlock = client.player.getSteppingPos().offset(client.player.getHorizontalFacing());
-        return (player.isSneaking() || !BedrockifyClient.getInstance().settings.isReacharoundSneakingEnabled()) && player.getPitch() > BedrockifyClient.getInstance().settings.getReacharoundPitchAngle() && player.isOnGround() && client.crosshairTarget.getType().equals(HitResult.Type.MISS) && checkRelativeBlockPosition() && ((client.world.getBlockState(facingSteppingBlock).getBlock() instanceof FluidBlock) || (client.world.getBlockState(facingSteppingBlock).getBlock() instanceof AirBlock));
+        final BlockPos targetPos = getFacingSteppingBlockPos(player);
+        return (player.isSneaking() || !BedrockifyClient.getInstance().settings.isReacharoundSneakingEnabled()) && player.getPitch() > BedrockifyClient.getInstance().settings.getReacharoundPitchAngle() && player.isOnGround() && client.crosshairTarget.getType().equals(HitResult.Type.MISS) && checkRelativeBlockPosition() && ((client.world.getBlockState(targetPos).getBlock() instanceof FluidBlock) || (client.world.getBlockState(targetPos).getBlock() instanceof AirBlock));
+    }
+
+    /**
+     * Helper method that retrieve Reach-Around block position.
+     *
+     * @return The position of the block to be placed.
+     */
+    public static BlockPos getFacingSteppingBlockPos(@NotNull Entity player) {
+        return player.getSteppingPos().offset(player.getHorizontalFacing());
     }
 
     private boolean checkRelativeBlockPosition() {

--- a/src/main/java/me/juancarloscp52/bedrockify/mixin/client/features/reacharoundPlacement/MinecraftClientMixin.java
+++ b/src/main/java/me/juancarloscp52/bedrockify/mixin/client/features/reacharoundPlacement/MinecraftClientMixin.java
@@ -4,20 +4,27 @@ package me.juancarloscp52.bedrockify.mixin.client.features.reacharoundPlacement;
 import me.juancarloscp52.bedrockify.client.BedrockifyClient;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.network.ClientPlayerEntity;
-import net.minecraft.item.ItemStack;
-import net.minecraft.util.Hand;
+import net.minecraft.util.hit.BlockHitResult;
+import net.minecraft.util.hit.HitResult;
+import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.thread.ReentrantThreadExecutor;
+import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 
 @Mixin(MinecraftClient.class)
 public abstract class MinecraftClientMixin extends ReentrantThreadExecutor<Runnable> {
-
-    @Shadow public ClientPlayerEntity player;
-    @Shadow public abstract boolean isInSingleplayer();
+    @Shadow
+    public ClientPlayerEntity player;
+    @Shadow
+    @Nullable
+    public HitResult crosshairTarget;
+    @Shadow
+    public abstract boolean isInSingleplayer();
 
     public MinecraftClientMixin(String string) {
         super(string);
@@ -27,13 +34,19 @@ public abstract class MinecraftClientMixin extends ReentrantThreadExecutor<Runna
     /**
      * Allows the player to use the reachAround placement feature if enabled.
      */
-    @Redirect(method = "doItemUse", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/network/ClientPlayerEntity;getStackInHand(Lnet/minecraft/util/Hand;)Lnet/minecraft/item/ItemStack;"))
-    private ItemStack onItemUse(ClientPlayerEntity player, Hand hand) {
-        ItemStack itemStack = this.player.getStackInHand(hand);
+    @Inject(method = "doItemUse", at = @At("HEAD"))
+    private void bedrockify$modifyCrosshairTarget(CallbackInfo ci) {
+        if (this.player == null) {
+            return;
+        }
+        if (!BedrockifyClient.getInstance().settings.isReacharoundEnabled() || (!isInSingleplayer() && !BedrockifyClient.getInstance().settings.isReacharoundMultiplayerEnabled())) {
+            return;
+        }
 
-        if (BedrockifyClient.getInstance().settings.isReacharoundEnabled() && (isInSingleplayer() || BedrockifyClient.getInstance().settings.isReacharoundMultiplayerEnabled()))
-            BedrockifyClient.getInstance().reachAroundPlacement.checkReachAroundAndExecute(hand, itemStack);
-
-        return itemStack;
+        if (BedrockifyClient.getInstance().reachAroundPlacement.canReachAround()) {
+            final ClientPlayerEntity player = this.player;
+            final BlockPos targetPos = player.getSteppingPos().offset(player.getHorizontalFacing());
+            this.crosshairTarget = new BlockHitResult(player.getPos(), player.getHorizontalFacing(), targetPos, false);
+        }
     }
 }

--- a/src/main/java/me/juancarloscp52/bedrockify/mixin/client/features/reacharoundPlacement/MinecraftClientMixin.java
+++ b/src/main/java/me/juancarloscp52/bedrockify/mixin/client/features/reacharoundPlacement/MinecraftClientMixin.java
@@ -2,6 +2,7 @@ package me.juancarloscp52.bedrockify.mixin.client.features.reacharoundPlacement;
 
 
 import me.juancarloscp52.bedrockify.client.BedrockifyClient;
+import me.juancarloscp52.bedrockify.client.features.reacharoundPlacement.ReachAroundPlacement;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.network.ClientPlayerEntity;
 import net.minecraft.util.hit.BlockHitResult;
@@ -45,7 +46,7 @@ public abstract class MinecraftClientMixin extends ReentrantThreadExecutor<Runna
 
         if (BedrockifyClient.getInstance().reachAroundPlacement.canReachAround()) {
             final ClientPlayerEntity player = this.player;
-            final BlockPos targetPos = player.getSteppingPos().offset(player.getHorizontalFacing());
+            final BlockPos targetPos = ReachAroundPlacement.getFacingSteppingBlockPos(player);
             this.crosshairTarget = new BlockHitResult(player.getPos(), player.getHorizontalFacing(), targetPos, false);
         }
     }


### PR DESCRIPTION
Refactor the feature of ReachAround placement. Shorter lines, more maintenability.

also resolve #211 

----

**Checklists**

Compatibility

- [x] with [Reacharound](https://www.curseforge.com/minecraft/mc-mods/reacharound)

Block placement

- Non-full block (updated)
  - [x] Dirt Path
  - [x] Soul Sand
  - [x] Mud
  - [x] Chests
  - [x] Chain
  - [x] Stonecutter
  - [x] Grindstone
  - [x] End Rod
  - [x] Bed
  - [x] Stairs, also on half position
  - [x] Slabs, also on upside-down position
  - [x] Fences
  - [x] Walls
  - [x] Cake
  - [x] Amethyst Buds, Cluster
  - [x] Sea Pickle
  - [x] Flower Pot
  - [x] Carpets
  - [x] Trapdoors
  - [x] Lectern
  - [x] Enchanting Table

----

**Changes**

* update `ReachAroundPlacement.java`
  - removed methods:
    + `isNonFullBlock`, use `Entity#getSteppingPos` instead
    + `checkReachAroundAndExecute`, due to injection method has changed
  - method access modifier has changed:
    + `canReachAround`: private -> public
  - in method `canReachAround`:
    + use `Entity#isOnGround` instead of checking the `BlockState`
    + use `Entity#getSteppingPos` instead of `BlockPos#down` to avoid collision error

* update `MinecraftClientMixin.java`
  - modify `MinecraftClient.crosshairTarget` instead of executing the unique method `checkReachAroundAndExecute`