### PR TITLE
[fix] handling op permission level

### DIFF
--- a/src/main/java/me/juancarloscp52/bedrockify/mixin/client/features/useAnimations/ClientPlayerEntityMixin.java
+++ b/src/main/java/me/juancarloscp52/bedrockify/mixin/client/features/useAnimations/ClientPlayerEntityMixin.java
@@ -12,6 +12,7 @@ import net.minecraft.item.Items;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Environment(EnvType.CLIENT)
@@ -38,15 +39,14 @@ public abstract class ClientPlayerEntityMixin extends AbstractClientPlayerEntity
      *
      * @see net.minecraft.entity.LivingEntity#damage
      * @see net.minecraft.world.World#sendEntityStatus
-     * @see net.minecraft.entity.LivingEntity#handleStatus
+     * @see net.minecraft.client.network.ClientPlayerEntity#handleStatus
      */
-    @Override
-    public void handleStatus(byte status) {
+    @Inject(method = "handleStatus", at = @At("HEAD"))
+    private void bedrockify$handleEntityStatus(byte status, CallbackInfo ci) {
         final ItemStack itemStack = this.getStackInHand(this.getActiveHand());
         if (status == 29 && itemStack.isOf(Items.SHIELD)) {
             // Blocked by shield
             AnimationsHelper.doBobbingAnimation(itemStack);
         }
-        super.handleStatus(status);
     }
 }


### PR DESCRIPTION
fix #218 

There is already a target method that overridden from the superclass.

* update `mixin.client.features.useAnimations.ClientPlayerEntityMixin`
  - change annotation `Override` -> `Inject`