### PR TITLE
[fix] reachAround target position

### DIFF
--- a/src/main/java/me/juancarloscp52/bedrockify/mixin/client/features/reacharoundPlacement/MinecraftClientMixin.java
+++ b/src/main/java/me/juancarloscp52/bedrockify/mixin/client/features/reacharoundPlacement/MinecraftClientMixin.java
@@ -8,6 +8,7 @@ import net.minecraft.client.network.ClientPlayerEntity;
 import net.minecraft.util.hit.BlockHitResult;
 import net.minecraft.util.hit.HitResult;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Vec3d;
 import net.minecraft.util.thread.ReentrantThreadExecutor;
 import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
@@ -47,7 +48,7 @@ public abstract class MinecraftClientMixin extends ReentrantThreadExecutor<Runna
         if (BedrockifyClient.getInstance().reachAroundPlacement.canReachAround()) {
             final ClientPlayerEntity player = this.player;
             final BlockPos targetPos = ReachAroundPlacement.getFacingSteppingBlockPos(player);
-            this.crosshairTarget = new BlockHitResult(player.getPos(), player.getHorizontalFacing(), targetPos, false);
+            this.crosshairTarget = new BlockHitResult(new Vec3d(targetPos.getX(), player.getY(), targetPos.getZ()), player.getHorizontalFacing(), targetPos, false);
         }
     }
 }


### PR DESCRIPTION
fix #220 

Get the reachAround target position instead of the player’s position when modifying `MinecraftClient#crosshairTarget`.

----

**Changes**

* update `mixin.client.features.reacharoundPlacement.MinecraftClientMixin`
  - `BlockHitResult#pos` should not the same as player's position