### PR TITLE
[refactor] Held Item Tooltips

### DIFF
--- a/src/main/java/me/juancarloscp52/bedrockify/client/features/heldItemTooltips/tooltip/PotionTooltip.java
+++ b/src/main/java/me/juancarloscp52/bedrockify/client/features/heldItemTooltips/tooltip/PotionTooltip.java
@@ -1,27 +1,18 @@
 package me.juancarloscp52.bedrockify.client.features.heldItemTooltips.tooltip;
 
-import net.minecraft.entity.effect.StatusEffectInstance;
 import net.minecraft.text.MutableText;
 import net.minecraft.text.Text;
-import net.minecraft.util.StringHelper;
 
 public class PotionTooltip extends Tooltip {
 
-    int ticks;
+    Text tooltip;
 
-    public PotionTooltip (StatusEffectInstance effect){
-        this.translationKey = effect.getTranslationKey();
-        this.primaryValue = effect.getAmplifier();
-        this.ticks = effect.getDuration();
+    public PotionTooltip (Text tooltip){
+        this.tooltip = tooltip;
     }
 
     @Override
     public MutableText getTooltipText() {
-        MutableText tooltip = Text.translatable(translationKey);
-        if(primaryValue>0)
-            tooltip.append(" ").append(Text.translatable("potion.potency." + primaryValue));
-        if(ticks>=20)
-            tooltip.append(" (" + StringHelper.formatTicks(ticks) + ")");
-        return tooltip;
+        return (MutableText) this.tooltip;
     }
 }

--- a/src/main/java/me/juancarloscp52/bedrockify/client/features/heldItemTooltips/tooltip/Tooltip.java
+++ b/src/main/java/me/juancarloscp52/bedrockify/client/features/heldItemTooltips/tooltip/Tooltip.java
@@ -7,5 +7,18 @@ public abstract class Tooltip {
     public int primaryValue;
 
     public abstract MutableText getTooltipText();
+
+    /**
+     * Overrides the original equals method to compare easier.
+     * @param that Another {@link Tooltip} object.
+     * @return <code>true</code> if they {@link Tooltip#getTooltipText()} are equal.
+     */
+    @Override
+    public boolean equals(Object that) {
+        if (!(that instanceof Tooltip tooltip)) {
+            return false;
+        }
+        return tooltip.getTooltipText().equals(this.getTooltipText());
+    }
 }
 


### PR DESCRIPTION
close #228 

Supports Lingering Potions, Water Bottle, Awkward Potion, and more.

----

**Changes**

* update `HeldItemTooltips.java`
  - method:
    + `getTooltips` become null-safe
    + `getTooltipsFromEffectList(List<StatusEffectInstance>)` -> `getTooltipsForPotion(List<Text>)`
    + `equals` become more simply
    + `drawItemWithCustomTooltips` handles `Text` instead of `Tooltip`

* update `PotionTooltip.java`
  - method: `<init>(StatusEffectInstance)` -> `<init>(Text)`
    + initialize with generated tooltip text

* update `Tooltip.java`
  - method: `equals`
    + overrides the Java utility method