### PR TITLE
[fix] limit useAnimations

### DIFF
--- a/src/main/java/me/juancarloscp52/bedrockify/client/features/useAnimations/AnimationsHelper.java
+++ b/src/main/java/me/juancarloscp52/bedrockify/client/features/useAnimations/AnimationsHelper.java
@@ -1,10 +1,17 @@
 package me.juancarloscp52.bedrockify.client.features.useAnimations;
 
 import me.juancarloscp52.bedrockify.client.BedrockifyClient;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
 
 public final class AnimationsHelper {
     public static final int ANIMATION_TIME = 5;
+
+    private static Item updatedItemInInventory = Items.AIR;
+
+    private AnimationsHelper() {
+    }
 
     /**
      * Bobbing!
@@ -20,5 +27,25 @@ public final class AnimationsHelper {
         }
 
         target.setBobbingAnimationTime(AnimationsHelper.ANIMATION_TIME);
+    }
+
+    /**
+     * Stores the changed item.
+     *
+     * @param itemStack Target itemStack.
+     */
+    public static void notifyChangedItem(ItemStack itemStack) {
+        updatedItemInInventory = itemStack.getItem();
+    }
+
+    /**
+     * Returns the stored item and reset it.
+     *
+     * @return Target item.
+     */
+    public static Item consumeChangedItem() {
+        final Item ret = updatedItemInInventory;
+        updatedItemInInventory = Items.AIR;
+        return ret;
     }
 }

--- a/src/main/java/me/juancarloscp52/bedrockify/client/features/useAnimations/AnimationsHelper.java
+++ b/src/main/java/me/juancarloscp52/bedrockify/client/features/useAnimations/AnimationsHelper.java
@@ -1,14 +1,12 @@
 package me.juancarloscp52.bedrockify.client.features.useAnimations;
 
 import me.juancarloscp52.bedrockify.client.BedrockifyClient;
-import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
-import net.minecraft.item.Items;
 
 public final class AnimationsHelper {
     public static final int ANIMATION_TIME = 5;
 
-    private static Item updatedItemInInventory = Items.AIR;
+    private static int updatedItemIdx = -1;
 
     private AnimationsHelper() {
     }
@@ -30,22 +28,22 @@ public final class AnimationsHelper {
     }
 
     /**
-     * Stores the changed item.
+     * Stores the slot index where the item changed.
      *
-     * @param itemStack Target itemStack.
+     * @param slotIdx Target slot index.
      */
-    public static void notifyChangedItem(ItemStack itemStack) {
-        updatedItemInInventory = itemStack.getItem();
+    public static void notifyChangedSlot(int slotIdx) {
+        updatedItemIdx = slotIdx;
     }
 
     /**
-     * Returns the stored item and reset it.
+     * Returns the stored slot index and reset it.
      *
      * @return Target item.
      */
-    public static Item consumeChangedItem() {
-        final Item ret = updatedItemInInventory;
-        updatedItemInInventory = Items.AIR;
+    public static int consumeChangedSlot() {
+        final int ret = updatedItemIdx;
+        updatedItemIdx = -1;
         return ret;
     }
 }

--- a/src/main/java/me/juancarloscp52/bedrockify/mixin/client/features/useAnimations/ClientPlayerEntityMixin.java
+++ b/src/main/java/me/juancarloscp52/bedrockify/mixin/client/features/useAnimations/ClientPlayerEntityMixin.java
@@ -7,12 +7,9 @@ import net.fabricmc.api.Environment;
 import net.minecraft.client.network.AbstractClientPlayerEntity;
 import net.minecraft.client.network.ClientPlayerEntity;
 import net.minecraft.client.world.ClientWorld;
-import net.minecraft.item.ItemStack;
-import net.minecraft.item.Items;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Environment(EnvType.CLIENT)
@@ -32,21 +29,5 @@ public abstract class ClientPlayerEntityMixin extends AbstractClientPlayerEntity
         }
 
         AnimationsHelper.doBobbingAnimation(this.getMainHandStack());
-    }
-
-    /**
-     * Handles the status message.
-     *
-     * @see net.minecraft.entity.LivingEntity#damage
-     * @see net.minecraft.world.World#sendEntityStatus
-     * @see net.minecraft.client.network.ClientPlayerEntity#handleStatus
-     */
-    @Inject(method = "handleStatus", at = @At("HEAD"))
-    private void bedrockify$handleEntityStatus(byte status, CallbackInfo ci) {
-        final ItemStack itemStack = this.getStackInHand(this.getActiveHand());
-        if (status == 29 && itemStack.isOf(Items.SHIELD)) {
-            // Blocked by shield
-            AnimationsHelper.doBobbingAnimation(itemStack);
-        }
     }
 }

--- a/src/main/java/me/juancarloscp52/bedrockify/mixin/client/features/useAnimations/ClientPlayerInteractionManagerMixin.java
+++ b/src/main/java/me/juancarloscp52/bedrockify/mixin/client/features/useAnimations/ClientPlayerInteractionManagerMixin.java
@@ -3,93 +3,43 @@ package me.juancarloscp52.bedrockify.mixin.client.features.useAnimations;
 import me.juancarloscp52.bedrockify.client.features.useAnimations.AnimationsHelper;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
-import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.network.ClientPlayerInteractionManager;
-import net.minecraft.entity.Entity;
-import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.player.PlayerEntity;
-import net.minecraft.item.*;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
+import net.minecraft.network.packet.Packet;
 import net.minecraft.util.ActionResult;
 import net.minecraft.util.Hand;
-import net.minecraft.util.math.BlockPos;
-import org.spongepowered.asm.mixin.Final;
+import org.apache.commons.lang3.mutable.MutableObject;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.Redirect;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Environment(EnvType.CLIENT)
 @Mixin(ClientPlayerInteractionManager.class)
 public abstract class ClientPlayerInteractionManagerMixin {
-    @Shadow
-    private @Final MinecraftClient client;
-
     /**
-     * Attack the entity, animate only damageable item.<br>
-     * When no damage may prevent Bobbing animation. e.g.) Unbreaking Enchantment
+     * This targets the lambda of {@link net.minecraft.client.network.SequencedPacketCreator} in {@link ClientPlayerInteractionManager#interactItem}.<br>
+     * It is not possible to retrieve their changes in {@link net.minecraft.client.network.ClientPlayNetworkHandler#onScreenHandlerSlotUpdate}.<br>
+     * This result is used in {@link AnimationsHelper#consumeChangedItem}.
      */
-    @Inject(method = "attackEntity", at = @At("RETURN"))
-    private void bedrockify$useWeaponBreakable(PlayerEntity player, Entity target, CallbackInfo ci) {
-        if (player == null) {
-            return;
-        }
-
-        if (!(target instanceof LivingEntity)) {
-            return;
-        }
-
-        final ItemStack itemStack = player.getMainHandStack();
-        if (itemStack.getItem() instanceof ToolItem) {
-            AnimationsHelper.doBobbingAnimation(itemStack);
-        }
-    }
-
-    /**
-     * Break the block and animate.
-     */
-    @Inject(method = "breakBlock", at = @At("RETURN"))
-    private void bedrockify$useToolBreakable(BlockPos pos, CallbackInfoReturnable<Boolean> cir) {
-        final PlayerEntity player = this.client.player;
-        if (!cir.getReturnValue() || player == null) {
-            return;
-        }
-
-        final ItemStack itemStack = player.getMainHandStack();
-        final Item item = itemStack.getItem();
-        if (item instanceof ToolItem || item == Items.SHEARS) {
-            AnimationsHelper.doBobbingAnimation(itemStack);
-        }
-    }
-
-    /**
-     * Placing a block, Using an item to block.
-     */
-    @Redirect(method = "interactBlockInternal", at = @At(value = "INVOKE", target = "Lnet/minecraft/item/ItemStack;useOnBlock(Lnet/minecraft/item/ItemUsageContext;)Lnet/minecraft/util/ActionResult;"))
-    private ActionResult bedrockify$useItemToBlock(ItemStack instance, ItemUsageContext context) {
-        final ActionResult actionResult = instance.useOnBlock(context);
-        if (actionResult.isAccepted() && context.getPlayer() != null && !context.getStack().isStackable()) {
-            AnimationsHelper.doBobbingAnimation(context.getPlayer().getStackInHand(context.getHand()));
-        }
-        return actionResult;
-    }
-
-    /**
-     * Do animate of consuming item.
-     */
-    @Inject(method = "interactItem", at = @At("RETURN"))
-    private void bedrockify$consumeItem(PlayerEntity player, Hand hand, CallbackInfoReturnable<ActionResult> cir) {
+    @Inject(method = "method_41929", at = @At("RETURN"))
+    private void bedrockify$consumeItem(Hand hand, PlayerEntity player, MutableObject<ActionResult> mutableObject, int sequence, CallbackInfoReturnable<Packet<?>> cir) {
         if (player == null) {
             return;
         }
 
         final ItemStack itemStack = player.getStackInHand(hand);
-        final ActionResult actionResult = cir.getReturnValue();
-        final boolean bNotSwingHandAnim = actionResult.isAccepted() && (itemStack.isOf(Items.GOAT_HORN) || itemStack.isOf(Items.ENDER_PEARL));
-        if (actionResult.shouldSwingHand() || bNotSwingHandAnim) {
-            AnimationsHelper.doBobbingAnimation(player.getStackInHand(hand));
+        if (itemStack.isOf(Items.GOAT_HORN)) {
+            AnimationsHelper.doBobbingAnimation(itemStack);
+            return;
         }
+
+        if (player.isCreative()) {
+            return;
+        }
+
+        AnimationsHelper.notifyChangedItem(itemStack);
     }
 }

--- a/src/main/java/me/juancarloscp52/bedrockify/mixin/client/features/useAnimations/ClientPlayerInteractionManagerMixin.java
+++ b/src/main/java/me/juancarloscp52/bedrockify/mixin/client/features/useAnimations/ClientPlayerInteractionManagerMixin.java
@@ -5,12 +5,11 @@ import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.minecraft.client.network.ClientPlayerInteractionManager;
 import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.entity.player.PlayerInventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
-import net.minecraft.network.packet.Packet;
 import net.minecraft.util.ActionResult;
 import net.minecraft.util.Hand;
-import org.apache.commons.lang3.mutable.MutableObject;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -22,10 +21,10 @@ public abstract class ClientPlayerInteractionManagerMixin {
     /**
      * This targets the lambda of {@link net.minecraft.client.network.SequencedPacketCreator} in {@link ClientPlayerInteractionManager#interactItem}.<br>
      * It is not possible to retrieve their changes in {@link net.minecraft.client.network.ClientPlayNetworkHandler#onScreenHandlerSlotUpdate}.<br>
-     * This result is used in {@link AnimationsHelper#consumeChangedItem}.
+     * This result is used in {@link AnimationsHelper#consumeChangedSlot}.
      */
-    @Inject(method = "method_41929", at = @At("RETURN"))
-    private void bedrockify$consumeItem(Hand hand, PlayerEntity player, MutableObject<ActionResult> mutableObject, int sequence, CallbackInfoReturnable<Packet<?>> cir) {
+    @Inject(method = "interactItem", at = @At("RETURN"))
+    private void bedrockify$consumeItem(PlayerEntity player, Hand hand, CallbackInfoReturnable<ActionResult> cir) {
         if (player == null) {
             return;
         }
@@ -40,6 +39,6 @@ public abstract class ClientPlayerInteractionManagerMixin {
             return;
         }
 
-        AnimationsHelper.notifyChangedItem(itemStack);
+        AnimationsHelper.notifyChangedSlot((hand == Hand.OFF_HAND) ? PlayerInventory.OFF_HAND_SLOT : player.getInventory().selectedSlot);
     }
 }


### PR DESCRIPTION
fix #244 , revert #207

The “Refine” will be reverted that I implemented.

This limits bobbing animations to conform to the specification of the previous version.

----

**Checklist**

- Do not animate when:
  - [x] Attack an Entity.
  - [x] Break a Block.
  - [x] Interact to a Block with an Item (such as Axe -> Logs).
  - [x] (Update) Use Fishing rod and Shears.
  - [x] (Update) Block an attack.
- Fix interruption of bobbing animation when:
  - [x] Throw eggs, snow balls, ender pearls and bottle o’ enchanting.
  - [x] Launch fireworks rocket for elytra flight.
  - [x] Use bucket items: Lava, Powder snow, Water and fill with Bucketable entity.

- [x] Also works when the item was in Offhand.

----

**Changes**

* update `AnimationsHelper`
  - add methods:
    + `notifyChangedSlot` to store Hotbar slot index of the changed item
    + `consumeChangedSlot` to retrieve which an item has been changed

* update `mixin.client.features.useAnimations.ClientPlayerInteractionManagerMixin`
  - injection methods have been removed:
    + `bedrockify$useWeaponBreakable`
    + `bedrockify$useToolBreakable`
    + `bedrockify$useItemToBlock`

* update `mixin.client.features.useAnimations.ClientPlayerEntityMixin`
  - injection method has been removed:
    + `bedrockify$handleEntityStatus`

* update `mixin.client.features.useAnimations.ClientPlayNetworkHandlerMixin`
  - method name has been changed:
    + `bedrockify$animateAlways` -> `bedrockify$animateAlwaysSlotUpdate`
  - new injection method has been added:
    + `bedrockify$animateAlwaysInventory` to handle the packet that could not be caught by `SlotUpdate`