### PR TITLE
Update BedrockifyClientSettings.java to avoid graphic glitch with simple voice mod

### DIFF
--- a/src/main/java/me/juancarloscp52/bedrockify/client/BedrockifyClientSettings.java
+++ b/src/main/java/me/juancarloscp52/bedrockify/client/BedrockifyClientSettings.java
@@ -27,7 +27,7 @@ public class BedrockifyClientSettings {
     }
 
     private final static List<Class<? extends Screen>> MINECRAFT_IGNORED_SCREENS = Arrays.asList(PackScreen.class, SocialInteractionsScreen.class);
-    public final static List<String> PANORAMA_IGNORED_SCREENS = Arrays.asList(".modmenu.gui.ModsScreen", ".iris.gui.", ".voicechat.gui",".modmanager.gui.", "yacl.gui.YACLScreen");
+    public final static List<String> PANORAMA_IGNORED_SCREENS = Arrays.asList(".modmenu.gui.ModsScreen", ".iris.gui.", ".voicechat.gui", ".modmanager.gui.", "yacl.gui.YACLScreen", "de.maxhenkel.voicechat");
     public boolean loadingScreen = true;
     public ButtonPosition bedrockIfyButtonPosition = ButtonPosition.BELOW_SLIDERS;
     public boolean showPositionHUD = true;


### PR DESCRIPTION
There is a graphic glitch within the group screen of the simple voice mod from henkelmax. The glitch happens, if the setting for the "show panoramascreen" is activ in BedrockIfy. I figured out, if the entry "de.maxhenkel.voicechat" is added to the disabled list for the panorama setting, the issue is gone and the panorama setting can be keep enabled.

https://github.com/henkelmax/simple-voice-chat/issues/565