### PR TITLE
[fix] SubtitlesHud

### DIFF
--- a/src/main/java/me/juancarloscp52/bedrockify/mixin/client/features/screenSafeArea/SubtitlesHudMixin.java
+++ b/src/main/java/me/juancarloscp52/bedrockify/mixin/client/features/screenSafeArea/SubtitlesHudMixin.java
@@ -15,31 +15,31 @@ public class SubtitlesHudMixin {
     @ModifyArgs(method = "render", at = @At(value = "INVOKE",target = "Lnet/minecraft/client/gui/DrawContext;drawTextWithShadow(Lnet/minecraft/client/font/TextRenderer;Ljava/lang/String;III)I"))
     private void modifyDrawText(Args args){
         int screenBorder = BedrockifyClient.getInstance().settings.getScreenSafeArea();
-        int x = args.get(3);
-        int y = args.get(4);
-        args.set(3,x - screenBorder);
-        args.set(4,y - screenBorder);
+        int x = args.get(2);
+        int y = args.get(3);
+        args.set(2, x - screenBorder);
+        args.set(3, y - screenBorder);
     }
 
     @ModifyArgs(method = "render", at = @At(value = "INVOKE",target = "Lnet/minecraft/client/gui/DrawContext;drawTextWithShadow(Lnet/minecraft/client/font/TextRenderer;Lnet/minecraft/text/Text;III)I"))
     public void modifyDrawText2(Args args){
         int screenBorder = BedrockifyClient.getInstance().settings.getScreenSafeArea();
-        int x = args.get(3);
-        int y = args.get(4);
-        args.set(3,x - screenBorder);
-        args.set(4,y - screenBorder);
+        int x = args.get(2);
+        int y = args.get(3);
+        args.set(2, x - screenBorder);
+        args.set(3, y - screenBorder);
     }
 
     @ModifyArgs(method = "render", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/DrawContext;fill(IIIII)V"))
     public void ModifyDrawText3(Args args){
         int screenBorder = BedrockifyClient.getInstance().settings.getScreenSafeArea();
-        int x1 = args.get(1);
-        int y1 = args.get(2);
-        int x2 = args.get(3);
-        int y2 = args.get(4);
-        args.set(1,x1 - screenBorder);
-        args.set(3,x2 - screenBorder);
-        args.set(2,y1 - screenBorder);
-        args.set(4,y2 - screenBorder);
+        int x1 = args.get(0);
+        int y1 = args.get(1);
+        int x2 = args.get(2);
+        int y2 = args.get(3);
+        args.set(0, x1 - screenBorder);
+        args.set(2, x2 - screenBorder);
+        args.set(1, y1 - screenBorder);
+        args.set(3, y2 - screenBorder);
     }
 }


### PR DESCRIPTION
fix #286 

Method arguments order in `DrawContext` class has been changed.

* update `screenSafeArea.SubtitlesHudMixin`
  - `DrawContext#drawTextWithShadow` -> (`TextRenderer`, `Text | String`, `x`, `y`, `color`)
  - `DrawContext#fill` -> (`x1`, `y1`, `x2`, `y2`, `color`)