### PR TITLE
[fix] SlotHighlight

### DIFF
--- a/src/main/java/me/juancarloscp52/bedrockify/client/BedrockifyClientSettings.java
+++ b/src/main/java/me/juancarloscp52/bedrockify/client/BedrockifyClientSettings.java
@@ -47,8 +47,8 @@ public class BedrockifyClientSettings {
     public boolean cubeMapBackground = true;
     public boolean bedrockChat = true;
     public boolean slotHighlight = true;
-    public int highLightColor1 = (255 << 8) + (255) + (255 << 16) + (255 << 24);
-    public int highLightColor2 = 64 + (170 << 8) + (109 << 16) + (255 << 24);
+    public int highLightColor1 = 0xffffffff;
+    public int highLightColor2 = 0x8955ba00;
     public float idleAnimation = 1;
     public double reacharoundBlockDistance = 0.5d;
     public int reacharoundPitchAngle = 25;

--- a/src/main/java/me/juancarloscp52/bedrockify/client/gui/SettingsGUI.java
+++ b/src/main/java/me/juancarloscp52/bedrockify/client/gui/SettingsGUI.java
@@ -105,8 +105,8 @@ public class SettingsGUI {
             //Item slot Highlight
             SubCategoryBuilder itemHighlight = entryBuilder.startSubCategory(Text.translatable("bedrockify.options.subCategory.inventoryHighlight"));
             itemHighlight.add(entryBuilder.startBooleanToggle(Text.translatable("bedrockify.options.inventoryHighlight"), settingsClient.slotHighlight).setDefaultValue(true).setSaveConsumer(newValue -> settingsClient.slotHighlight=newValue).build());
-            itemHighlight.add(entryBuilder.startAlphaColorField(Text.translatable("bedrockify.options.inventoryHighlight.color1"), settingsClient.highLightColor1).setDefaultValue((255 << 8) + (255) + (255 << 16) + (255 << 24)).setSaveConsumer(newValue -> settingsClient.highLightColor1=newValue).build());
-            itemHighlight.add(entryBuilder.startAlphaColorField(Text.translatable("bedrockify.options.inventoryHighlight.color2"), settingsClient.highLightColor2).setDefaultValue(64 + (170 << 8) + (109 << 16) + (255 << 24)).setSaveConsumer(newValue -> settingsClient.highLightColor2=newValue).build());
+            itemHighlight.add(entryBuilder.startAlphaColorField(Text.translatable("bedrockify.options.inventoryHighlight.color1"), settingsClient.highLightColor1).setDefaultValue(0xffffffff).setSaveConsumer(newValue -> settingsClient.highLightColor1=newValue).build());
+            itemHighlight.add(entryBuilder.startAlphaColorField(Text.translatable("bedrockify.options.inventoryHighlight.color2"), settingsClient.highLightColor2).setDefaultValue(0x8955ba00).setSaveConsumer(newValue -> settingsClient.highLightColor2=newValue).build());
             gui.addEntry(itemHighlight.build());
 
             // Screen Safe Area

--- a/src/main/java/me/juancarloscp52/bedrockify/mixin/client/features/slotHighlight/HandledScreenMixin.java
+++ b/src/main/java/me/juancarloscp52/bedrockify/mixin/client/features/slotHighlight/HandledScreenMixin.java
@@ -1,58 +1,107 @@
 package me.juancarloscp52.bedrockify.mixin.client.features.slotHighlight;
 
-
-import com.mojang.blaze3d.systems.RenderSystem;
 import me.juancarloscp52.bedrockify.client.BedrockifyClient;
 import me.juancarloscp52.bedrockify.client.BedrockifyClientSettings;
-import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.DrawContext;
-import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.gui.screen.ingame.*;
 import net.minecraft.screen.slot.Slot;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(HandledScreen.class)
 public abstract class HandledScreenMixin {
+    @Unique
+    private static final int LINE_RENDER_WIDTH = 1;
+    @Unique
+    private static final int SLOT_RENDER_SIZE = 16;
+    @Unique
+    private Slot currentSlot;
 
     @Shadow
-    protected Slot focusedSlot;
+    protected int x;
+    @Shadow
+    protected int y;
 
-    @Shadow protected abstract void drawSlot(DrawContext context, Slot slot);
+    @Shadow
+    abstract boolean isPointOverSlot(Slot slot, double pointX, double pointY);
+
+    @Inject(method = "drawSlotHighlight", at = @At("HEAD"), cancellable = true)
+    private static void bedrockify$cancelVanillaHighlight(DrawContext context, int x, int y, int z, CallbackInfo ci) {
+        BedrockifyClientSettings settings = BedrockifyClient.getInstance().settings;
+        if (settings.isSlotHighlightEnabled()) {
+            ci.cancel();
+        }
+    }
+
+    @ModifyVariable(method = "render", at = @At("STORE"))
+    private Slot bedrockify$storeSlotInLoop(Slot slot) {
+        this.currentSlot = slot;
+        return slot;
+    }
 
     /**
      * Draw the current slot in green.
      */
-    @Redirect(method = "render", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/screen/ingame/HandledScreen;drawSlotHighlight(Lnet/minecraft/client/gui/DrawContext;III)V"))
-    protected void renderGuiQuad(DrawContext drawContext, int x, int y, int color) {
+    @Inject(method = "render", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/screen/ingame/HandledScreen;drawSlot(Lnet/minecraft/client/gui/DrawContext;Lnet/minecraft/screen/slot/Slot;)V"))
+    private void bedrockify$customHighlightColor(DrawContext drawContext, int mouseX, int mouseY, float delta, CallbackInfo ci) {
         BedrockifyClientSettings settings = BedrockifyClient.getInstance().settings;
-        if(!settings.isSlotHighlightEnabled()){
-            RenderSystem.disableDepthTest();
-            RenderSystem.colorMask(true, true, true, false);
-            drawContext.fillGradient(x, y, x + 16, y + 16, -2130706433, -2130706433, color);
-            RenderSystem.colorMask(true, true, true, true);
-            RenderSystem.enableDepthTest();            return;
+        if (!settings.isSlotHighlightEnabled() || this.currentSlot == null) {
+            return;
         }
-        int xEnd=x+16,yEnd=y+16;
-        Screen currentScreen = MinecraftClient.getInstance().currentScreen;
-        if((currentScreen instanceof AbstractFurnaceScreen && focusedSlot.id==2)||(currentScreen instanceof CraftingScreen && focusedSlot.id==0) || (currentScreen instanceof StonecutterScreen && focusedSlot.id==1) ||(currentScreen instanceof CartographyTableScreen && focusedSlot.id==2)){
-            drawContext.fillGradient(x - 5, y - 5, xEnd + 5, yEnd + 5, settings.getHighLightColor1(), settings.getHighLightColor1());
-            drawContext.fillGradient(x -4, y -4, xEnd+4, yEnd+4, settings.getHighLightColor2(), settings.getHighLightColor2());
-        }else if ((currentScreen instanceof LoomScreen && focusedSlot.id==3)) {
-            drawContext.fillGradient(x - 5, y - 6, xEnd + 5, yEnd + 4, settings.getHighLightColor1(), settings.getHighLightColor1());
-            drawContext.fillGradient(x -4, y -5, xEnd+4, yEnd+3, settings.getHighLightColor2(), settings.getHighLightColor2());
-        }else if((currentScreen instanceof MerchantScreen && focusedSlot.id==2)){
-            drawContext.fillGradient(x - 5, y - 4, xEnd + 5, yEnd + 6, settings.getHighLightColor1(), settings.getHighLightColor1());
-            drawContext.fillGradient(x -4, y -3, xEnd+4, yEnd+5, settings.getHighLightColor2(), settings.getHighLightColor2());
-        }else{
-            drawContext.fillGradient(x - 1, y - 1, xEnd + 1, yEnd + 1, settings.getHighLightColor1(), settings.getHighLightColor1());
-            drawContext.fillGradient(x, y, xEnd, yEnd, settings.getHighLightColor2(), settings.getHighLightColor2());
+        if (!this.isPointOverSlot(currentSlot, mouseX, mouseY) || !currentSlot.isEnabled()) {
+            return;
         }
-        // Draw the slot again over the selected overlay.
-        this.drawSlot(drawContext, focusedSlot);
+
+        final HandledScreen<?> $this = HandledScreen.class.cast(this);
+        final int highlight1 = settings.getHighLightColor1();
+        final int highlight2 = settings.getHighLightColor2();
+
+        final int expandStartX, expandStartY, expandEndX, expandEndY;
+        if (($this instanceof AbstractFurnaceScreen && currentSlot.id == 2) ||
+                ($this instanceof CraftingScreen && currentSlot.id == 0) ||
+                ($this instanceof StonecutterScreen && currentSlot.id == 1) ||
+                ($this instanceof CartographyTableScreen && currentSlot.id == 2)
+        ) {
+            expandStartX = expandEndX = 4;
+            expandStartY = expandEndY = 4;
+        } else if ($this instanceof LoomScreen && currentSlot.id == 3) {
+            expandStartX = expandEndX = 4;
+            expandStartY = 5;
+            expandEndY = 3;
+        } else if ($this instanceof MerchantScreen && currentSlot.id == 2) {
+            expandStartX = expandEndX = 4;
+            expandStartY = 3;
+            expandEndY = 5;
+        } else {
+            expandStartX = expandEndX = expandStartY = expandEndY = 0;
+        }
+
+        final int fillStartX = currentSlot.x - expandStartX;
+        final int fillStartY = currentSlot.y - expandStartY;
+        final int fillEndX = currentSlot.x + expandEndX + SLOT_RENDER_SIZE;
+        final int fillEndY = currentSlot.y + expandEndY + SLOT_RENDER_SIZE;
+        final int outlineLeftX = fillStartX - LINE_RENDER_WIDTH;
+        final int outlineTopY = fillStartY - LINE_RENDER_WIDTH;
+        final int outlineRightX = fillEndX + LINE_RENDER_WIDTH;
+        final int outlineBottomY = fillEndY + LINE_RENDER_WIDTH;
+
+        // ** outlines
+        // Top-horizontal
+        drawContext.fill(outlineLeftX, outlineTopY, outlineRightX, outlineTopY + LINE_RENDER_WIDTH, highlight1);
+        // Bottom-horizontal
+        drawContext.fill(outlineLeftX, outlineBottomY - LINE_RENDER_WIDTH, outlineRightX, outlineBottomY, highlight1);
+        // Left-vertical
+        drawContext.fill(outlineLeftX, outlineTopY, outlineLeftX + LINE_RENDER_WIDTH, outlineBottomY, highlight1);
+        // Right-vertical
+        drawContext.fill(outlineRightX - LINE_RENDER_WIDTH, outlineTopY, outlineRightX, outlineBottomY, highlight1);
+        // ** end of outlines
+
+        // highlight
+        drawContext.fill(fillStartX, fillStartY, fillEndX, fillEndY, highlight2);
     }
-
-
 }


### PR DESCRIPTION
fix #285 

This also supports highlight opacity.

I remember an issue that it’d be nice to be able to see the slot background, and now it’s possible. But there are some limitations; the blending functionality is based on its alpha and sprite, so it needs to calculate backwards from the target color. In some cases, there are colors that cannot be produced.

This figure shows the case where the color of Item Slot Highlight Foreground is `#8955ba00`:
![Screenshot from 2023-07-09 16-17-44](https://github.com/juancarloscp52/BedrockIfy/assets/74746227/15932ac8-bd9b-4a7a-a666-4f153220a754)

Note that resourcepacks and/or mods can easily change the sprites and it’s difficult to get the color you want.

----

**Changes**

* update `slotHighlight.HandledScreenMixin`
  - method injection point has changed: `drawSlotHighlight` -> `drawSlot`
  - remove shadow methods/fields: `drawSlot(DrawContext, Slot)`, `focusedSlot`
  - add shadow methods/fields: `isPointOverSlot(Slot, double, double)`, `x`, `y`
  - supports opacity