### PR TITLE
[fix][compat] YetAnotherConfigLib

### DIFF
--- a/src/main/java/me/juancarloscp52/bedrockify/client/BedrockifyClientSettings.java
+++ b/src/main/java/me/juancarloscp52/bedrockify/client/BedrockifyClientSettings.java
@@ -27,7 +27,7 @@ public class BedrockifyClientSettings {
     }
 
     private final static List<Class<? extends Screen>> MINECRAFT_IGNORED_SCREENS = Arrays.asList(PackScreen.class, SocialInteractionsScreen.class);
-    public final static List<String> PANORAMA_IGNORED_SCREENS = Arrays.asList(".modmenu.gui.ModsScreen", ".iris.gui.", ".voicechat.gui",".modmanager.gui.", "yacl.gui.YACLScreen");
+    public final static List<String> PANORAMA_IGNORED_SCREENS = Arrays.asList(".modmenu.gui.ModsScreen", ".iris.gui.", ".voicechat.gui",".modmanager.gui.", "yacl.gui.YACLScreen", "yacl3.gui.YACLScreen");
     public boolean loadingScreen = true;
     public ButtonPosition bedrockIfyButtonPosition = ButtonPosition.BELOW_SLIDERS;
     public boolean showPositionHUD = true;
@@ -75,7 +75,8 @@ public class BedrockifyClientSettings {
 
     public List<String> panoramaIgnoredScreens = PANORAMA_IGNORED_SCREENS;
 
-    public boolean panoramaIgnoreScreen(Screen screen) {
+    public boolean panoramaIgnoreScreen() {
+        Screen screen = MinecraftClient.getInstance().currentScreen;
         if (screen != null) {
             // Checks if the screen is a Minecraft screen that would break in any case
             if (MINECRAFT_IGNORED_SCREENS.contains(screen.getClass()))

--- a/src/main/java/me/juancarloscp52/bedrockify/mixin/client/features/panoramaBackground/EntryListWidgetMixin.java
+++ b/src/main/java/me/juancarloscp52/bedrockify/mixin/client/features/panoramaBackground/EntryListWidgetMixin.java
@@ -54,6 +54,6 @@ public abstract class EntryListWidgetMixin {
     }
 
     private boolean shouldIgnoreScreen() {
-        return BedrockifyClient.getInstance().settings.panoramaIgnoreScreen(this.client.currentScreen);
+        return BedrockifyClient.getInstance().settings.panoramaIgnoreScreen();
     }
 }

--- a/src/main/java/me/juancarloscp52/bedrockify/mixin/client/features/panoramaBackground/ScreenMixin.java
+++ b/src/main/java/me/juancarloscp52/bedrockify/mixin/client/features/panoramaBackground/ScreenMixin.java
@@ -13,15 +13,12 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(Screen.class)
 public abstract class ScreenMixin {
-
-    @Shadow protected MinecraftClient client;
-
     /**
      * Renders the rotating cube map on screens instead of the dirt texture if enabled.
      */
     @Inject(method = "renderBackgroundTexture", at = @At("HEAD"), cancellable = true)
     public void renderTexture(DrawContext drawContext, CallbackInfo info) {
-        if(!BedrockifyClient.getInstance().settings.isCubemapBackgroundEnabled() || BedrockifyClient.getInstance().settings.panoramaIgnoreScreen(this.client.currentScreen) /*|| this.client.currentScreen.getClass().getName().contains(".modmanager.gui.") /* Mod Manager */)
+        if(!BedrockifyClient.getInstance().settings.isCubemapBackgroundEnabled() || BedrockifyClient.getInstance().settings.panoramaIgnoreScreen() /*|| this.client.currentScreen.getClass().getName().contains(".modmanager.gui.") /* Mod Manager */)
             return;
         BedrockifyRotatingCubeMapRenderer.getInstance().render(drawContext);
         info.cancel();

--- a/src/main/java/me/juancarloscp52/bedrockify/mixin/client/features/panoramaBackground/TabButtonWidgetMixin.java
+++ b/src/main/java/me/juancarloscp52/bedrockify/mixin/client/features/panoramaBackground/TabButtonWidgetMixin.java
@@ -32,7 +32,7 @@ public abstract class TabButtonWidgetMixin extends ClickableWidget {
 
     @Inject(method = "renderButton", at=@At("HEAD"),cancellable = true)
     public void renderButton(DrawContext drawContext, int mouseX, int mouseY, float delta, CallbackInfo ci) {
-        if(!BedrockifyClient.getInstance().settings.cubeMapBackground)
+        if(!BedrockifyClient.getInstance().settings.cubeMapBackground || BedrockifyClient.getInstance().settings.panoramaIgnoreScreen())
             return;
         drawContext.drawNineSlicedTexture(TEXTURE, this.getX(), this.getY(), this.width, this.height, 2, 2, 2, 0, 130, 24, 0, this.getTextureV());
         if(!this.isCurrentTab()){

--- a/src/main/java/me/juancarloscp52/bedrockify/mixin/client/features/panoramaBackground/TabNavigationWidgetMixin.java
+++ b/src/main/java/me/juancarloscp52/bedrockify/mixin/client/features/panoramaBackground/TabNavigationWidgetMixin.java
@@ -35,7 +35,7 @@ public abstract class TabNavigationWidgetMixin {
     @Inject(method = "render",at=@At("HEAD"),cancellable = true)
     public void render(DrawContext drawContext, int mouseX, int mouseY, float delta, CallbackInfo ci) {
 
-        if(!BedrockifyClient.getInstance().settings.cubeMapBackground)
+        if(!BedrockifyClient.getInstance().settings.cubeMapBackground || BedrockifyClient.getInstance().settings.panoramaIgnoreScreen())
             return;
 
         //Panorama background


### PR DESCRIPTION
fix #289

The namespace of YetAnotherConfigLib has changed since v3.

This change applies a check to `TabButtonWidget` and `TabNavigationWidget` to ignore cubemap rendering.

----

**Changes**

* update `client.BedrockifyClientSettings`
  - add entry `yacl3.gui.YACLScreen` to `PANORAMA_IGNORED_SCREENS`
  - change method signature: `panoramaIgnoreScreen(Screen)` -> `void`

* update panorama background:
  - `mixin.client.features.panoramaBackground.EntryListWidgetMixin`
  - `mixin.client.features.panoramaBackground.ScreenMixin`
  - `mixin.client.features.panoramaBackground.TabButtonWidgetMixin`
  - `mixin.client.features.panoramaBackground.TabNavigationWidgetMixin`