### PR TITLE
Improve reach-around parity by using raycast calculations instead of pitch equality

### DIFF
--- a/src/main/java/me/juancarloscp52/bedrockify/client/BedrockifyClientSettings.java
+++ b/src/main/java/me/juancarloscp52/bedrockify/client/BedrockifyClientSettings.java
@@ -30,8 +30,8 @@ public class BedrockifyClientSettings {
     public boolean showPaperDoll = true;
     public boolean showChunkMap = false;
     public boolean reacharound = true;
-    public boolean reacharoundSneaking = true;
-    public boolean reacharoundIndicator = true;
+    public boolean reacharoundSneaking = false;
+    public boolean reacharoundIndicator = false;
     public boolean reacharoundMultiplayer = true;
     public int positionHUDHeight = 50;
     public int screenSafeArea = 0;
@@ -41,8 +41,6 @@ public class BedrockifyClientSettings {
     public int highLightColor1 = 0xffffffff;
     public int highLightColor2 = 0x8955ba00;
     public float idleAnimation = 1;
-    public double reacharoundBlockDistance = 0.5d;
-    public int reacharoundPitchAngle = 25;
     public boolean savingOverlay = true;
     public boolean eatingAnimations = true;
     public boolean expTextStyle = true;
@@ -103,14 +101,6 @@ public class BedrockifyClientSettings {
 
     public byte getFPSHUDoption() {
         return FPSHUD;
-    }
-
-    public double getReacharoundBlockDistance() {
-        return reacharoundBlockDistance;
-    }
-
-    public int getReacharoundPitchAngle() {
-        return reacharoundPitchAngle;
     }
 
     public boolean isShowPaperDollEnabled() {

--- a/src/main/java/me/juancarloscp52/bedrockify/client/features/reacharoundPlacement/ReachAroundPlacement.java
+++ b/src/main/java/me/juancarloscp52/bedrockify/client/features/reacharoundPlacement/ReachAroundPlacement.java
@@ -27,7 +27,7 @@ public class ReachAroundPlacement {
     }
 
     public boolean canReachAround() {
-        if (client.player == null || client.world == null || client.crosshairTarget == null || client.interactionManager == null)
+        if (client.player == null || client.world == null || client.crosshairTarget == null)
             return false;
 
         // crosshairTarget must be MISS.

--- a/src/main/java/me/juancarloscp52/bedrockify/client/features/reacharoundPlacement/ReachAroundPlacement.java
+++ b/src/main/java/me/juancarloscp52/bedrockify/client/features/reacharoundPlacement/ReachAroundPlacement.java
@@ -1,15 +1,17 @@
 package me.juancarloscp52.bedrockify.client.features.reacharoundPlacement;
 
 import me.juancarloscp52.bedrockify.client.BedrockifyClient;
-import net.minecraft.block.BlockState;
-import net.minecraft.block.FluidBlock;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.network.ClientPlayerEntity;
 import net.minecraft.entity.Entity;
 import net.minecraft.util.hit.HitResult;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Box;
+import net.minecraft.util.math.Vec3d;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.Optional;
 
 public class ReachAroundPlacement {
     private final MinecraftClient client;
@@ -25,7 +27,7 @@ public class ReachAroundPlacement {
     }
 
     public boolean canReachAround() {
-        if (client.player == null || client.world == null || client.crosshairTarget == null)
+        if (client.player == null || client.world == null || client.crosshairTarget == null || client.interactionManager == null)
             return false;
 
         // crosshairTarget must be MISS.
@@ -41,15 +43,15 @@ public class ReachAroundPlacement {
             return false;
         }
         // Player may be flying, climbing the ladder or vines, or on the Fluid with sneaking.
-        if (!player.isOnGround() || !isSolidBlock(client.world.getBlockState(player.getSteppingPos()))) {
+        if (!player.isOnGround()) {
             return false;
         }
-        // There is already a block at the ReachAround target position.
-        if (isSolidBlock(client.world.getBlockState(targetPos))) {
+        // There is a non-replaceable block at the ReachAround target position.
+        if (!client.world.getBlockState(targetPos).isReplaceable()) {
             return false;
         }
 
-        return player.getPitch() > BedrockifyClient.getInstance().settings.getReacharoundPitchAngle() && checkRelativeBlockPosition();
+        return getRaycastIntersection(player).isPresent();
     }
 
     /**
@@ -62,28 +64,18 @@ public class ReachAroundPlacement {
     }
 
     /**
-     * Helper method that checks the BlockState is not AIR and FLUIDS.
-     *
-     * @param blockState The target blockState.
-     * @return <code>true</code> if the block is not AIR and FLUIDS.
+     * Draws a vector from the player's eyes to the end of the reach distance, in the direction the player is facing. We can use this to check if the block is valid for placement.
+     * @return The position of the intersection between the raycast and the surface of the target block.
+     * @author axialeaa
      */
-    private static boolean isSolidBlock(@NotNull BlockState blockState) {
-        return !blockState.isAir() && !(blockState.getBlock() instanceof FluidBlock);
-    }
-
-    private boolean checkRelativeBlockPosition() {
-        if (client.player == null)
-            return false;
-        return checkRelativeBlockPosition((client.player.getPos().getX() - client.player.getBlockPos().getX()), client.player.getHorizontalFacing().getUnitVector().x()) || checkRelativeBlockPosition((client.player.getPos().getZ() - client.player.getBlockPos().getZ()), client.player.getHorizontalFacing().getUnitVector().z());
-    }
-
-    private boolean checkRelativeBlockPosition(double pos, float direction) {
-        double distance = BedrockifyClient.getInstance().settings.getReacharoundBlockDistance();
-        if (direction > 0) {
-            return 1-pos < distance;
-        } else if (direction < 0) {
-            return pos < distance;
+    private Optional<Vec3d> getRaycastIntersection(@NotNull Entity player) {
+        if (client.interactionManager == null) {
+            return Optional.empty(); // Redundant in 1.20.5+
         }
-        return false;
+
+        Vec3d rayStartPos = player.getEyePos();
+        Vec3d rayEndPos = player.getRotationVec(1.0F).multiply(client.interactionManager.getReachDistance()).add(rayStartPos);
+                                                                    // player.getBlockInteractionRange() in 1.20.5+
+        return new Box(getFacingSteppingBlockPos(player)).raycast(rayStartPos, rayEndPos);
     }
 }

--- a/src/main/java/me/juancarloscp52/bedrockify/client/gui/SettingsGUI.java
+++ b/src/main/java/me/juancarloscp52/bedrockify/client/gui/SettingsGUI.java
@@ -56,7 +56,8 @@ public class SettingsGUI {
             reachAround.add(entryBuilder.startBooleanToggle(Text.translatable("bedrockify.options.reachAround.multiplayer"), settingsClient.reacharoundMultiplayer).setDefaultValue(true).setSaveConsumer(newValue -> settingsClient.reacharoundMultiplayer=newValue).build());
             reachAround.add(entryBuilder.startBooleanToggle(Text.translatable("bedrockify.options.reachAround.sneaking"), settingsClient.reacharoundSneaking).setDefaultValue(false).setSaveConsumer(newValue -> settingsClient.reacharoundSneaking=newValue).build());
             reachAround.add(entryBuilder.startBooleanToggle(Text.translatable("bedrockify.options.reachAround.indicator"), settingsClient.reacharoundIndicator).setDefaultValue(false).setSaveConsumer(newValue -> settingsClient.reacharoundIndicator=newValue).build());
-
+            gameplay.addEntry(reachAround.build());
+        
             // Dying and Fallen Trees.
             gameplay.addEntry(entryBuilder.startBooleanToggle(Text.translatable("bedrockify.options.dyingTrees"), settingsCommon.dyingTrees).setDefaultValue(true).setSaveConsumer(newValue -> settingsCommon.dyingTrees=newValue).build());
             gameplay.addEntry(entryBuilder.startBooleanToggle(Text.translatable("bedrockify.options.fallenTrees"), settingsCommon.fallenTrees).setDefaultValue(true).setSaveConsumer(newValue -> settingsCommon.fallenTrees=newValue).build());

--- a/src/main/java/me/juancarloscp52/bedrockify/client/gui/SettingsGUI.java
+++ b/src/main/java/me/juancarloscp52/bedrockify/client/gui/SettingsGUI.java
@@ -54,11 +54,8 @@ public class SettingsGUI {
             reachAround.add(entryBuilder.startTextDescription(Text.translatable("bedrockify.options.subCategory.Reach-Around.description")).build());
             reachAround.add(entryBuilder.startBooleanToggle(Text.translatable("bedrockify.options.reachAround"), settingsClient.reacharound).setDefaultValue(true).setSaveConsumer(newValue -> settingsClient.reacharound=newValue).build());
             reachAround.add(entryBuilder.startBooleanToggle(Text.translatable("bedrockify.options.reachAround.multiplayer"), settingsClient.reacharoundMultiplayer).setDefaultValue(true).setSaveConsumer(newValue -> settingsClient.reacharoundMultiplayer=newValue).build());
-            reachAround.add(entryBuilder.startBooleanToggle(Text.translatable("bedrockify.options.reachAround.sneaking"), settingsClient.reacharoundSneaking).setDefaultValue(true).setSaveConsumer(newValue -> settingsClient.reacharoundSneaking=newValue).build());
-            reachAround.add(entryBuilder.startBooleanToggle(Text.translatable("bedrockify.options.reachAround.indicator"), settingsClient.reacharoundIndicator).setDefaultValue(true).setSaveConsumer(newValue -> settingsClient.reacharoundIndicator=newValue).build());
-            reachAround.add(entryBuilder.startIntSlider(Text.translatable("bedrockify.options.reachAround.pitch"), settingsClient.reacharoundPitchAngle, 0,90).setDefaultValue(25).setSaveConsumer(newValue -> settingsClient.reacharoundPitchAngle=newValue).build());
-            reachAround.add(entryBuilder.startIntSlider(Text.translatable("bedrockify.options.reachAround.distance"), MathHelper.floor(settingsClient.reacharoundBlockDistance*100), 0,100).setTextGetter((integer -> Text.literal(String.valueOf(integer/100d)))).setDefaultValue(75).setSaveConsumer(newValue -> settingsClient.reacharoundBlockDistance=newValue/100d).build());
-            gameplay.addEntry(reachAround.build());
+            reachAround.add(entryBuilder.startBooleanToggle(Text.translatable("bedrockify.options.reachAround.sneaking"), settingsClient.reacharoundSneaking).setDefaultValue(false).setSaveConsumer(newValue -> settingsClient.reacharoundSneaking=newValue).build());
+            reachAround.add(entryBuilder.startBooleanToggle(Text.translatable("bedrockify.options.reachAround.indicator"), settingsClient.reacharoundIndicator).setDefaultValue(false).setSaveConsumer(newValue -> settingsClient.reacharoundIndicator=newValue).build());
 
             // Dying and Fallen Trees.
             gameplay.addEntry(entryBuilder.startBooleanToggle(Text.translatable("bedrockify.options.dyingTrees"), settingsCommon.dyingTrees).setDefaultValue(true).setSaveConsumer(newValue -> settingsCommon.dyingTrees=newValue).build());

--- a/src/main/resources/assets/bedrockify/lang/de_de.json
+++ b/src/main/resources/assets/bedrockify/lang/de_de.json
@@ -28,8 +28,6 @@
   "bedrockify.options.reachAround.multiplayer": "Multiplayer Reach-Around:",
   "bedrockify.options.recipes": "Benutze Bedrock Crafting Rezepte:",
   "bedrockify.options.recipes.tooltip": "Welt erneut öffnen, um Änderungen zu übernehmen.",
-  "bedrockify.options.reachAround.pitch": "Minimaler Neigungswinkel:",
-  "bedrockify.options.reachAround.distance": "Maximaler Abstand vom Blockrand:",
   "bedrockify.options.chatStyle": "Chat Stil:",
   "bedrockify.options.chatStyle.bedrock": "Bedrock",
   "bedrockify.options.chatStyle.vanilla": "Java",

--- a/src/main/resources/assets/bedrockify/lang/en_us.json
+++ b/src/main/resources/assets/bedrockify/lang/en_us.json
@@ -36,8 +36,6 @@
   "bedrockify.options.reachAround.multiplayer": "Multiplayer Reach-Around:",
   "bedrockify.options.recipes": "Use Bedrock Crafting Recipes:",
   "bedrockify.options.recipes.tooltip": "Must re-open world to apply changes.",
-  "bedrockify.options.reachAround.pitch": "Minimum Pitch Angle:",
-  "bedrockify.options.reachAround.distance": "Maximum Distance from the Block Border:",
   "bedrockify.options.chatStyle": "Chat Style:",
   "bedrockify.options.chatStyle.bedrock": "Bedrock",
   "bedrockify.options.chatStyle.vanilla": "Java",

--- a/src/main/resources/assets/bedrockify/lang/es_ar.json
+++ b/src/main/resources/assets/bedrockify/lang/es_ar.json
@@ -53,8 +53,6 @@
   "bedrockify.options.pickupAnimations": "Animación de objetos en Hotbar:",
   "bedrockify.options.pickupAnimations.tooltip": "Habilita las animaciones de la edición bedrock mostradas en la barra de objetos cuando recoges, usas o dañas objetos.",
   "bedrockify.options.loadingScreen": "Usar pantallas de carga de la edición Bedrock:",
-  "bedrockify.options.reachAround.pitch": "Ángulo de inclinación mínimo:",
-  "bedrockify.options.reachAround.distance": "Distancia máxima desde el borde del bloque:",
   "bedrockify.options.inventoryHighlight.color1": "Color de fondo de resalto de slot:",
   "bedrockify.options.inventoryHighlight.color2": "Color principal de resalto de slot:",
   "bedrockify.options.expTextStyle": "Estilo de texto de experiencia:",

--- a/src/main/resources/assets/bedrockify/lang/es_cl.json
+++ b/src/main/resources/assets/bedrockify/lang/es_cl.json
@@ -53,8 +53,6 @@
   "bedrockify.options.pickupAnimations": "Animación de objetos en Hotbar:",
   "bedrockify.options.pickupAnimations.tooltip": "Habilita las animaciones de la edición bedrock mostradas en la barra de objetos cuando recoges, usas o dañas objetos.",
   "bedrockify.options.loadingScreen": "Usar pantallas de carga de la edición Bedrock:",
-  "bedrockify.options.reachAround.pitch": "Ángulo de inclinación mínimo:",
-  "bedrockify.options.reachAround.distance": "Distancia máxima desde el borde del bloque:",
   "bedrockify.options.inventoryHighlight.color1": "Color de fondo de resalto de slot:",
   "bedrockify.options.inventoryHighlight.color2": "Color principal de resalto de slot:",
   "bedrockify.options.expTextStyle": "Estilo de texto de experiencia:",

--- a/src/main/resources/assets/bedrockify/lang/es_ec.json
+++ b/src/main/resources/assets/bedrockify/lang/es_ec.json
@@ -53,8 +53,6 @@
   "bedrockify.options.pickupAnimations": "Animación de objetos en Hotbar:",
   "bedrockify.options.pickupAnimations.tooltip": "Habilita las animaciones de la edición bedrock mostradas en la barra de objetos cuando recoges, usas o dañas objetos.",
   "bedrockify.options.loadingScreen": "Usar pantallas de carga de la edición Bedrock:",
-  "bedrockify.options.reachAround.pitch": "Ángulo de inclinación mínimo:",
-  "bedrockify.options.reachAround.distance": "Distancia máxima desde el borde del bloque:",
   "bedrockify.options.inventoryHighlight.color1": "Color de fondo de resalto de slot:",
   "bedrockify.options.inventoryHighlight.color2": "Color principal de resalto de slot:",
   "bedrockify.options.expTextStyle": "Estilo de texto de experiencia:",

--- a/src/main/resources/assets/bedrockify/lang/es_es.json
+++ b/src/main/resources/assets/bedrockify/lang/es_es.json
@@ -53,8 +53,6 @@
   "bedrockify.options.pickupAnimations": "Animación de objetos en Hotbar:",
   "bedrockify.options.pickupAnimations.tooltip": "Habilita las animaciones de la edición bedrock mostradas en la barra de objetos cuando recoges, usas o dañas objetos.",
   "bedrockify.options.loadingScreen": "Usar pantallas de carga de la edición Bedrock:",
-  "bedrockify.options.reachAround.pitch": "Ángulo de inclinación mínimo:",
-  "bedrockify.options.reachAround.distance": "Distancia máxima desde el borde del bloque:",
   "bedrockify.options.inventoryHighlight.color1": "Color de fondo de resalto de slot:",
   "bedrockify.options.inventoryHighlight.color2": "Color principal de resalto de slot:",
   "bedrockify.options.expTextStyle": "Estilo de texto de experiencia:",

--- a/src/main/resources/assets/bedrockify/lang/es_mx.json
+++ b/src/main/resources/assets/bedrockify/lang/es_mx.json
@@ -53,8 +53,6 @@
   "bedrockify.options.pickupAnimations": "Animación de objetos en Hotbar:",
   "bedrockify.options.pickupAnimations.tooltip": "Habilita las animaciones de la edición bedrock mostradas en la barra de objetos cuando recoges, usas o dañas objetos.",
   "bedrockify.options.loadingScreen": "Usar pantallas de carga de la edición Bedrock:",
-  "bedrockify.options.reachAround.pitch": "Ángulo de inclinación mínimo:",
-  "bedrockify.options.reachAround.distance": "Distancia máxima desde el borde del bloque:",
   "bedrockify.options.inventoryHighlight.color1": "Color de fondo de resalto de slot:",
   "bedrockify.options.inventoryHighlight.color2": "Color principal de resalto de slot:",
   "bedrockify.options.expTextStyle": "Estilo de texto de experiencia:",

--- a/src/main/resources/assets/bedrockify/lang/es_uy.json
+++ b/src/main/resources/assets/bedrockify/lang/es_uy.json
@@ -53,8 +53,6 @@
   "bedrockify.options.pickupAnimations": "Animación de objetos en Hotbar:",
   "bedrockify.options.pickupAnimations.tooltip": "Habilita las animaciones de la edición bedrock mostradas en la barra de objetos cuando recoges, usas o dañas objetos.",
   "bedrockify.options.loadingScreen": "Usar pantallas de carga de la edición Bedrock:",
-  "bedrockify.options.reachAround.pitch": "Ángulo de inclinación mínimo:",
-  "bedrockify.options.reachAround.distance": "Distancia máxima desde el borde del bloque:",
   "bedrockify.options.inventoryHighlight.color1": "Color de fondo de resalto de slot:",
   "bedrockify.options.inventoryHighlight.color2": "Color principal de resalto de slot:",
   "bedrockify.options.expTextStyle": "Estilo de texto de experiencia:",

--- a/src/main/resources/assets/bedrockify/lang/es_ve.json
+++ b/src/main/resources/assets/bedrockify/lang/es_ve.json
@@ -53,8 +53,6 @@
   "bedrockify.options.pickupAnimations": "Animación de objetos en Hotbar:",
   "bedrockify.options.pickupAnimations.tooltip": "Habilita las animaciones de la edición bedrock mostradas en la barra de objetos cuando recoges, usas o dañas objetos.",
   "bedrockify.options.loadingScreen": "Usar pantallas de carga de la edición Bedrock:",
-  "bedrockify.options.reachAround.pitch": "Ángulo de inclinación mínimo:",
-  "bedrockify.options.reachAround.distance": "Distancia máxima desde el borde del bloque:",
   "bedrockify.options.inventoryHighlight.color1": "Color de fondo de resalto de slot:",
   "bedrockify.options.inventoryHighlight.color2": "Color principal de resalto de slot:",
   "bedrockify.options.expTextStyle": "Estilo de texto de experiencia:",

--- a/src/main/resources/assets/bedrockify/lang/fr_fr.json
+++ b/src/main/resources/assets/bedrockify/lang/fr_fr.json
@@ -27,8 +27,6 @@
   "bedrockify.options.reachAround.multiplayer": "Placement de proximité en multijoueur:",
   "bedrockify.options.recipes": "Utiliser les recettes de fabrication Bedrock:",
   "bedrockify.options.recipes.tooltip": "Vous devez rouvrir le monde pour appliquer les modifications.",
-  "bedrockify.options.reachAround.pitch": "Angle de tangage minimum:",
-  "bedrockify.options.reachAround.distance": "Distance maximale depuis le bord du bloc :",
   "bedrockify.options.chatStyle": "Style du chat:",
   "bedrockify.options.chatStyle.bedrock": "Bedrock",
   "bedrockify.options.chatStyle.vanilla": "Java",

--- a/src/main/resources/assets/bedrockify/lang/pl_pl.json
+++ b/src/main/resources/assets/bedrockify/lang/pl_pl.json
@@ -36,8 +36,6 @@
   "bedrockify.options.reachAround.multiplayer": "Strategia sięgnij-dookoła w trybie wieloosobowym:",
   "bedrockify.options.recipes": "Użyj przepisów tworzenia z Bedrocka:",
   "bedrockify.options.recipes.tooltip": "Musisz ponownie otworzyć świat, aby zaaplikować zmiany.",
-  "bedrockify.options.reachAround.pitch": "Minimalne odchylenie ręki ręki:",
-  "bedrockify.options.reachAround.distance": "Maximalna odległość od bloku:",
   "bedrockify.options.chatStyle": "Styl czatu:",
   "bedrockify.options.chatStyle.bedrock": "Bedrock",
   "bedrockify.options.chatStyle.vanilla": "Java",

--- a/src/main/resources/assets/bedrockify/lang/pt_br.json
+++ b/src/main/resources/assets/bedrockify/lang/pt_br.json
@@ -27,8 +27,6 @@
   "bedrockify.options.reachAround.multiplayer": "Alcance Multiplayer:",
   "bedrockify.options.recipes": "Use Receitas de Criação de Bedrock:",
   "bedrockify.options.recipes.tooltip": "Deve reabrir o mundo para aplicar as mudanças.",
-  "bedrockify.options.reachAround.pitch": "Angulo minimo de inclinação:",
-  "bedrockify.options.reachAround.distance": "Distância máxima da borda do bloco:",
   "bedrockify.options.chatStyle": "Estilo do Chat:",
   "bedrockify.options.chatStyle.bedrock": "Bedrock",
   "bedrockify.options.chatStyle.vanilla": "Java",

--- a/src/main/resources/assets/bedrockify/lang/ru_ru.json
+++ b/src/main/resources/assets/bedrockify/lang/ru_ru.json
@@ -28,8 +28,6 @@
   "bedrockify.options.reachAround.multiplayer": "Использовать на серверах:",
   "bedrockify.options.recipes": "Использовать рецепты из Bedrock:",
   "bedrockify.options.recipes.tooltip": "Нужно перезайти в мир для применения изменений.",
-  "bedrockify.options.reachAround.pitch": "Минимальный угол наклона головы:",
-  "bedrockify.options.reachAround.distance": "Максимальное расстояние до края блока:",
   "bedrockify.options.chatStyle": "Стиль чата:",
   "bedrockify.options.chatStyle.bedrock": "Bedrock",
   "bedrockify.options.chatStyle.vanilla": "Java",

--- a/src/main/resources/assets/bedrockify/lang/sr_sp.json
+++ b/src/main/resources/assets/bedrockify/lang/sr_sp.json
@@ -27,8 +27,6 @@
   "bedrockify.options.reachAround.multiplayer": "Дохват около са више играча:",
   "bedrockify.options.recipes": "Користи бедрок рецепте за прављење:",
   "bedrockify.options.recipes.tooltip": "Мораш поново отворити свет да се измене примене.",
-  "bedrockify.options.reachAround.pitch": "Минимални угао нагиба:",
-  "bedrockify.options.reachAround.distance": "Максимална удаљеност од границе блока:",
   "bedrockify.options.chatStyle": "Стил чета:",
   "bedrockify.options.chatStyle.bedrock": "Бедрок",
   "bedrockify.options.chatStyle.vanilla": "Јава",

--- a/src/main/resources/assets/bedrockify/lang/tr_tr.json
+++ b/src/main/resources/assets/bedrockify/lang/tr_tr.json
@@ -27,8 +27,6 @@
   "bedrockify.options.reachAround.multiplayer": "Çoklu Oyuncuda Öne Blok Koyma:",
   "bedrockify.options.recipes": "Bedrock Üretim Tariflerini Kullan:",
   "bedrockify.options.recipes.tooltip": "Değişikliklerin uygulanması için dünyaya yeniden girilmeli.",
-  "bedrockify.options.reachAround.pitch": "Minimum Eğim Açısı:",
-  "bedrockify.options.reachAround.distance": "Blok Sınırından Maksimum Mesafe:",
   "bedrockify.options.chatStyle": "Sohbet Stili:",
   "bedrockify.options.chatStyle.bedrock": "Bedrock",
   "bedrockify.options.chatStyle.vanilla": "Java",

--- a/src/main/resources/assets/bedrockify/lang/uk_ua.json
+++ b/src/main/resources/assets/bedrockify/lang/uk_ua.json
@@ -28,8 +28,6 @@
   "bedrockify.options.reachAround.multiplayer": "Використовувати у мережі",
   "bedrockify.options.recipes": "Використовувати рецепти майстрування з Bedrock Edition",
   "bedrockify.options.recipes.tooltip": "Щоб застосувати зміни, потрібно повторно відкрити світ.",
-  "bedrockify.options.reachAround.pitch": "Мінімальний кут розміщення",
-  "bedrockify.options.reachAround.distance": "Максимальна відстань від ребра блока",
   "bedrockify.options.chatStyle": "Стиль чату",
   "bedrockify.options.chatStyle.bedrock": "Bedrock",
   "bedrockify.options.chatStyle.vanilla": "Java",

--- a/src/main/resources/assets/bedrockify/lang/vi_vn.json
+++ b/src/main/resources/assets/bedrockify/lang/vi_vn.json
@@ -36,8 +36,6 @@
   "bedrockify.options.reachAround.multiplayer": "Đặt khối gần cạnh khi chơi mạng:",
   "bedrockify.options.recipes": "Dùng công thức chế tạo của Bedrock:",
   "bedrockify.options.recipes.tooltip": "Cần mở lại thế giới để áp dụng thay đổi.",
-  "bedrockify.options.reachAround.pitch": "Góc nghiêng tối thiểu:",
-  "bedrockify.options.reachAround.distance": "Khoảng cách tối đa từ viền khối:",
   "bedrockify.options.chatStyle": "Kiểu Chat:",
   "bedrockify.options.chatStyle.bedrock": "Bedrock",
   "bedrockify.options.chatStyle.vanilla": "Java",

--- a/src/main/resources/assets/bedrockify/lang/zh_cn.json
+++ b/src/main/resources/assets/bedrockify/lang/zh_cn.json
@@ -27,8 +27,6 @@
   "bedrockify.options.reachAround.multiplayer": "多人游戏四周放置:",
   "bedrockify.options.recipes": "使用基岩版合成配方：",
   "bedrockify.options.recipes.tooltip": "必须重新加载世界以应用更改。",
-  "bedrockify.options.reachAround.pitch": "最小俯仰角：",
-  "bedrockify.options.reachAround.distance": "从方块边缘的最大距离：",
   "bedrockify.options.chatStyle": "聊天框样式:",
   "bedrockify.options.chatStyle.bedrock": "基岩版",
   "bedrockify.options.chatStyle.vanilla": "Java 版",


### PR DESCRIPTION
Hi! I'm making this pull request to highlight a proposition for a more parity-friendly approach to the reach-around placement feature, alongside a couple of other related changes.

My main idea here is that the old pitch check for calculating whether a block is eligible for reach-around placement should be dropped in favour of a small bit of math to check if a vector drawn from the player's eyes to the end of their reach distance intersects with the block position in front of them. This is functionally more accurate (identical?) to vanilla Bedrock's implementation:
```JAVA
private Optional<Vec3d> getRaycastIntersection(@NotNull Entity player) {
    if (client.interactionManager == null) {
        return Optional.empty();
    }

    Vec3d rayStartPos = player.getEyePos();
    Vec3d rayEndPos = player.getRotationVec(1.0F).multiply(client.interactionManager.getReachDistance()).add(rayStartPos);

    return new Box(getFacingSteppingBlockPos(player)).raycast(rayStartPos, rayEndPos);
}
```
The main `canReachAround()` method now just returns `getRaycastIntersection(player).isPresent()`.

One drawback of this change which may be a controversial make-or-break, is the now-obsolescence of the config options used to specify the distance and pitch requirements. The distance is handled within the raycasting math itself, so it doesn't make sense to reference it elsewhere. That being said, while writing this, I did attempt to make the raycast length customisable. However, it turned out to be far too confusing to use in my opinion as it didn't modify the functionality proportionate to the player's location on the block. I'm open to other ideas. :)

Some additional changes in this pull request:
- Removed the old solid block check and replaced it with an `isReplaceable()` call. This also helps with parity.
- Modified the default values of some reach-around-related config options in order to match vanilla Bedrock Edition.
  - reacharoundSneaking is now set to false
  - reacharoundIndicator is now set to false