### PR TITLE
[enhancement] Remove Cauldrons when mixin is disabled

### DIFF
--- a/src/main/java/me/juancarloscp52/bedrockify/Bedrockify.java
+++ b/src/main/java/me/juancarloscp52/bedrockify/Bedrockify.java
@@ -1,11 +1,12 @@
 package me.juancarloscp52.bedrockify;
 
 import com.google.gson.Gson;
-import me.juancarloscp52.bedrockify.common.payloads.CauldronParticlePayload;
-import me.juancarloscp52.bedrockify.common.payloads.EatParticlePayload;
 import me.juancarloscp52.bedrockify.common.block.cauldron.BedrockCauldronBehavior;
 import me.juancarloscp52.bedrockify.common.features.cauldron.BedrockCauldronBlocks;
 import me.juancarloscp52.bedrockify.common.features.worldGeneration.DyingTrees;
+import me.juancarloscp52.bedrockify.common.payloads.CauldronParticlePayload;
+import me.juancarloscp52.bedrockify.common.payloads.EatParticlePayload;
+import me.juancarloscp52.bedrockify.mixin.featureManager.MixinFeatureManager;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
 import net.fabricmc.fabric.api.networking.v1.PayloadTypeRegistry;
@@ -34,10 +35,12 @@ public class Bedrockify implements ModInitializer {
         loadSettings();
         instance = this;
         DyingTrees.registerTrees();
-        BedrockCauldronBlocks.register();
         PayloadTypeRegistry.playS2C().register(Bedrockify.EAT_PARTICLE_PAYLOAD.getId(), EatParticlePayload.CODEC);
         PayloadTypeRegistry.playS2C().register(Bedrockify.CAULDRON_PARTICLE_PAYLOAD.getId(), CauldronParticlePayload.CODEC);
-        ServerLifecycleEvents.SERVER_STARTED.register(server -> BedrockCauldronBehavior.registerBehavior());
+        if (MixinFeatureManager.features.get(MixinFeatureManager.FEAT_CAULDRON)) {
+            BedrockCauldronBlocks.register();
+            ServerLifecycleEvents.SERVER_STARTED.register(server -> BedrockCauldronBehavior.registerBehavior());
+        }
     }
 
     public void loadSettings() {

--- a/src/main/java/me/juancarloscp52/bedrockify/client/BedrockifyClient.java
+++ b/src/main/java/me/juancarloscp52/bedrockify/client/BedrockifyClient.java
@@ -12,11 +12,12 @@ import me.juancarloscp52.bedrockify.client.features.sheepColors.SheepSkinResourc
 import me.juancarloscp52.bedrockify.client.features.worldColorNoise.WorldColorNoiseSampler;
 import me.juancarloscp52.bedrockify.client.gui.Overlay;
 import me.juancarloscp52.bedrockify.client.gui.SettingsGUI;
-import me.juancarloscp52.bedrockify.common.payloads.CauldronParticlePayload;
-import me.juancarloscp52.bedrockify.common.payloads.EatParticlePayload;
 import me.juancarloscp52.bedrockify.common.block.cauldron.BedrockCauldronBehavior;
 import me.juancarloscp52.bedrockify.common.block.entity.WaterCauldronBlockEntity;
 import me.juancarloscp52.bedrockify.common.features.cauldron.BedrockCauldronBlocks;
+import me.juancarloscp52.bedrockify.common.payloads.CauldronParticlePayload;
+import me.juancarloscp52.bedrockify.common.payloads.EatParticlePayload;
+import me.juancarloscp52.bedrockify.mixin.featureManager.MixinFeatureManager;
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientLifecycleEvents;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
@@ -81,20 +82,22 @@ public class BedrockifyClient implements ClientModInitializer {
         // Register 3D Bobber Entity.
         EntityModelLayerRegistry.registerModelLayer(FishingBobber3DModel.MODEL_LAYER, FishingBobber3DModel::generateModel);
 
-        // Register the Color Tint of Potion-filled and Colored Cauldron Block.
-        ColorProviderRegistry.BLOCK.register((state, world, pos, tintIndex) -> {
-            if (world == null || pos == null) {
-                return -1;
-            }
+        // Register the Color Tint of Potion-filled and Colored Cauldron Block if enabled.
+        if (MixinFeatureManager.features.get(MixinFeatureManager.FEAT_CAULDRON)) {
+            ColorProviderRegistry.BLOCK.register((state, world, pos, tintIndex) -> {
+                if (world == null || pos == null) {
+                    return -1;
+                }
 
-            final Optional<WaterCauldronBlockEntity> entity = world.getBlockEntity(pos, BedrockCauldronBlocks.WATER_CAULDRON_ENTITY);
-            return entity.map(WaterCauldronBlockEntity::getTintColor).orElse(-1);
-        }, BedrockCauldronBlocks.POTION_CAULDRON, BedrockCauldronBlocks.COLORED_WATER_CAULDRON);
+                final Optional<WaterCauldronBlockEntity> entity = world.getBlockEntity(pos, BedrockCauldronBlocks.WATER_CAULDRON_ENTITY);
+                return entity.map(WaterCauldronBlockEntity::getTintColor).orElse(-1);
+            }, BedrockCauldronBlocks.POTION_CAULDRON, BedrockCauldronBlocks.COLORED_WATER_CAULDRON);
 
-        // Lazy initialization of Bedrock's cauldron behavior after all the registries are ready.
-        ClientLifecycleEvents.CLIENT_STARTED.register(client -> {
-            BedrockCauldronBehavior.registerBehavior();
-        });
+            // Lazy initialization of Bedrock's cauldron behavior after all the registries are ready.
+            ClientLifecycleEvents.CLIENT_STARTED.register(client -> {
+                BedrockCauldronBehavior.registerBehavior();
+            });
+        }
 
         // Register sheared sheep texture dynamically.
         if (!FabricLoader.getInstance().isModLoaded("optifabric")) {

--- a/src/main/java/me/juancarloscp52/bedrockify/mixin/common/workaround/cauldron/TagGroupLoaderMixin.java
+++ b/src/main/java/me/juancarloscp52/bedrockify/mixin/common/workaround/cauldron/TagGroupLoaderMixin.java
@@ -1,0 +1,23 @@
+package me.juancarloscp52.bedrockify.mixin.common.workaround.cauldron;
+
+import me.juancarloscp52.bedrockify.Bedrockify;
+import me.juancarloscp52.bedrockify.mixin.featureManager.MixinFeatureManager;
+import net.minecraft.registry.tag.TagEntry;
+import net.minecraft.registry.tag.TagGroupLoader;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.List;
+
+@Mixin(TagGroupLoader.class)
+public abstract class TagGroupLoaderMixin {
+    /** The lambda of <code>tagFile.entries().forEach((entryx) -> { ... } );</code> */
+    @Inject(method = "method_43954(Ljava/util/List;Ljava/lang/String;Lnet/minecraft/registry/tag/TagEntry;)V", at = @At("HEAD"), cancellable = true)
+    private static void bedrockify$removeCauldronFromTag(List<TagGroupLoader.TrackedEntry> instance, String packName, TagEntry entryx, CallbackInfo ci) {
+        if (packName.equals(Bedrockify.MOD_ID) && !MixinFeatureManager.features.get(MixinFeatureManager.FEAT_CAULDRON) && entryx.toString().contains("cauldron")) {
+            ci.cancel();
+        }
+    }
+}

--- a/src/main/java/me/juancarloscp52/bedrockify/mixin/featureManager/MixinFeatureManager.java
+++ b/src/main/java/me/juancarloscp52/bedrockify/mixin/featureManager/MixinFeatureManager.java
@@ -14,6 +14,8 @@ import java.util.Map;
 
 public class MixinFeatureManager {
 
+    public static final String FEAT_CAULDRON = "common.features.cauldron";
+
     public static Map<String, Boolean> features = new HashMap<>();
     static {
         features.put("client.core.clientRenderTimer", true);
@@ -39,7 +41,7 @@ public class MixinFeatureManager {
         features.put("common.features.fireAspect", true);
         features.put("common.features.fertilizableBlocks", true);
         features.put("common.features.animalEatingParticles", true);
-        features.put("common.features.cauldron", true);
+        features.put(FEAT_CAULDRON, true);
         features.put("common.features.fernBonemeal", true);
         features.put("client.features.hudOpacity", true);
         features.put("client.features.editionBranding", true);
@@ -50,7 +52,7 @@ public class MixinFeatureManager {
         mixin = mixin.replace("me.juancarloscp52.bedrockify.mixin.","");
         String [] split = mixin.split("\\.");
         mixin = mixin.replace("."+split[split.length-1],"");
-        if(mixin.contains("worldGeneration")){
+        if(mixin.contains("worldGeneration") || mixin.contains("workaround")){
             return true;
         }
         return features.get(mixin);

--- a/src/main/resources/bedrockify.mixins.json
+++ b/src/main/resources/bedrockify.mixins.json
@@ -50,6 +50,7 @@
     "common.features.animalEatingParticles.WolfEntityMixin",
     "common.features.cauldron.ArmorDyeRecipeMixin",
     "common.features.cauldron.CauldronBehaviorMixin",
+    "common.workaround.cauldron.TagGroupLoaderMixin",
     "common.features.fernBonemeal.GrassBlockMixin",
     "common.features.fertilizableBlocks.FlowerBlockMixin",
     "common.features.fertilizableBlocks.SugarCaneBlockMixin",


### PR DESCRIPTION
Provides only Bedrock UI if you want.

close #325

> [!WARNING]
> This changes can BREAK the Bedrock-like cauldrons that already exists in the world.
> Please modify the mixin settings carefully, and I recommend that DO NOT CHANGE SETTINGS while the world is still alive.

Of course, it needs to restart the instance after changing the settings.

Behavior Checklist:
- [x] BedrockCauldron - $\color{green}\textsf{YES}$, mixin common.feature.cauldron - $\color{green}\textsf{YES}$ -> Features are enabled
- [x] BedrockCauldron - $\color{red}\textsf{NO}$, mixin common.feature.cauldron - $\color{green}\textsf{YES}$ -> Blocks are still alive, but cannot interact
- [x] BedrockCauldron - $\color{green}\textsf{YES}$, mixin common.feature.cauldron - $\color{red}\textsf{NO}$ -> Blocks are gone, features are disabled
- [x] BedrockCauldron - $\color{red}\textsf{NO}$, mixin common.feature.cauldron - $\color{red}\textsf{NO}$ -> Java Cauldron behavior

----

Changes

method `onInitialize*` in Bedrockify, BedrockifyClient:
- Checks the cauldron mixin via MixinFeatureManager before registering the blocks

Registers a new mixin to correct loot table for cauldron:
- mixin.common.workaround.cauldron.TagGroupLoaderMixin
- it will avoid to apply data/minecraft/tags/blocks/cauldrons.json