### PR TITLE
fix horse eating particles

### DIFF
--- a/src/main/java/me/juancarloscp52/bedrockify/mixin/common/features/animalEatingParticles/HorseEntityMixin.java
+++ b/src/main/java/me/juancarloscp52/bedrockify/mixin/common/features/animalEatingParticles/HorseEntityMixin.java
@@ -14,7 +14,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 @Mixin(AbstractHorseEntity.class)
 public class HorseEntityMixin{
 
-    @Inject(method = "interactHorse",at=@At("HEAD"))
+    @Inject(method = "interactHorse",at=@At(value = "INVOKE", target = "Lnet/minecraft/item/ItemStack;decrementUnlessCreative(ILnet/minecraft/entity/LivingEntity;)V"))
     public void eat (PlayerEntity player, ItemStack stack, CallbackInfoReturnable<ActionResult> cir){
         EatingParticlesUtil.spawnItemParticles(player, stack, ((AnimalEntity)(Object)this));
     }


### PR DESCRIPTION
resolve #377 

Avoids particle spawn when not receiving foods.

----

**Changes**

Injection point has been changed:
- `mixin.common.features.animalEatingParticles.HorseEntityMixin`