### PR TITLE
More compatible with 1.21.9

### DIFF
--- a/src/main/java/me/juancarloscp52/bedrockify/client/features/bedrockShading/BedrockBlockShading.java
+++ b/src/main/java/me/juancarloscp52/bedrockify/client/features/bedrockShading/BedrockBlockShading.java
@@ -11,9 +11,10 @@ public class BedrockBlockShading {
 
     public float getBlockShade (Direction direction){
         MinecraftClient client = MinecraftClient.getInstance();
+        boolean isNether = client.player != null && client.player.getEntityWorld().getRegistryKey() == World.NETHER;
         return switch (direction) {
             case UP -> 1.0f;
-            case DOWN -> client.player.getEntityWorld().getRegistryKey() == World.NETHER ? 0.9f : 0.87f;
+            case DOWN -> isNether ? 0.9f : 0.87f;
             case NORTH, SOUTH -> 0.95f;
             default -> 0.9f;
         };

--- a/src/main/java/me/juancarloscp52/bedrockify/common/block/PotionCauldronBlock.java
+++ b/src/main/java/me/juancarloscp52/bedrockify/common/block/PotionCauldronBlock.java
@@ -117,7 +117,7 @@ public class PotionCauldronBlock extends AbstractBECauldronBlock {
 
         if (!state.contains(LEVEL)) {
             Bedrockify.LOGGER.error(
-                    "[%s] cannot retrieve fluid level".formatted(Bedrockify.class.getSimpleName()),
+                    "[{}] cannot retrieve fluid level", Bedrockify.class.getSimpleName(),
                     new IllegalStateException("BlockState of %s does not have state: %s".formatted(state.getBlock(), LEVEL)));
             return false;
         }
@@ -158,7 +158,7 @@ public class PotionCauldronBlock extends AbstractBECauldronBlock {
     public static int getMaxTippedArrowCount(ItemStack itemStack, BlockState state) {
         if (!state.contains(LEVEL)) {
             Bedrockify.LOGGER.error(
-                    "[%s] cannot retrieve fluid level".formatted(Bedrockify.class.getSimpleName()),
+                    "[{}] cannot retrieve fluid level", Bedrockify.class.getSimpleName(),
                     new IllegalStateException("BlockState of %s does not have the state: LEVEL".formatted(state.getBlock())));
             return 0;
         }

--- a/src/main/java/me/juancarloscp52/bedrockify/mixin/client/features/bedrockShading/sunGlare/SkyRenderingMixin.java
+++ b/src/main/java/me/juancarloscp52/bedrockify/mixin/client/features/bedrockShading/sunGlare/SkyRenderingMixin.java
@@ -1,123 +1,33 @@
 package me.juancarloscp52.bedrockify.mixin.client.features.bedrockShading.sunGlare;
 
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
-import com.mojang.blaze3d.buffers.GpuBuffer;
-import com.mojang.blaze3d.buffers.GpuBufferSlice;
-import com.mojang.blaze3d.systems.RenderPass;
-import com.mojang.blaze3d.systems.RenderSystem;
-import com.mojang.blaze3d.textures.GpuTextureView;
-import com.mojang.blaze3d.vertex.VertexFormat;
 import me.juancarloscp52.bedrockify.client.BedrockifyClient;
 import me.juancarloscp52.bedrockify.client.features.bedrockShading.BedrockSunGlareShading;
-import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.gl.RenderPipelines;
-import net.minecraft.client.render.*;
-import net.minecraft.client.render.state.SkyRenderState;
-import net.minecraft.client.texture.AbstractTexture;
-import net.minecraft.client.texture.TextureManager;
-import net.minecraft.client.util.BufferAllocator;
-import net.minecraft.client.util.math.MatrixStack;
-import net.minecraft.client.world.ClientWorld;
-import net.minecraft.util.Identifier;
+import net.minecraft.client.render.SkyRendering;
 import net.minecraft.util.math.MathHelper;
-import net.minecraft.util.math.Vec3d;
 import org.joml.Matrix4f;
 import org.joml.Matrix4fStack;
-import org.joml.Vector3f;
 import org.joml.Vector4f;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
-import org.spongepowered.asm.mixin.gen.Accessor;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-
-import java.util.Objects;
-import java.util.OptionalDouble;
-import java.util.OptionalInt;
 
 @Mixin(SkyRendering.class)
 public abstract class SkyRenderingMixin {
     @Unique
     private final BedrockSunGlareShading sunGlareShading = BedrockifyClient.getInstance().bedrockSunGlareShading;
-    @Unique
-    private GpuBuffer sunVertexBuffer;
-    @Unique
-    private int sunIndexCount;
 
-    @Accessor("SUN_TEXTURE")
-    public static Identifier getSunTextureId() {
-        throw new AssertionError();
-    }
-
-    @Inject(method = "<init>", at = @At("RETURN"))
-    private void bedrockify$SkyRenderingCtor(CallbackInfo ci) {
-        // Allocate buffer.
-        try (BufferAllocator bufferAllocator = BufferAllocator.fixedSized(4 * VertexFormats.POSITION_TEXTURE_COLOR.getVertexSize())) {
-            BufferBuilder bufferBuilder = new BufferBuilder(bufferAllocator, VertexFormat.DrawMode.QUADS, VertexFormats.POSITION_TEXTURE_COLOR);
-
-            Matrix4f matrix4f = new Matrix4f();
-            bufferBuilder.vertex(matrix4f, -30.0F, 100.0F, -30.0F).texture(0.0F, 0.0F).color(-1);
-            bufferBuilder.vertex(matrix4f, 30.0F, 100.0F, -30.0F).texture(1.0F, 0.0F).color(-1);
-            bufferBuilder.vertex(matrix4f, 30.0F, 100.0F, 30.0F).texture(1.0F, 1.0F).color(-1);
-            bufferBuilder.vertex(matrix4f, -30.0F, 100.0F, 30.0F).texture(0.0F, 1.0F).color(-1);
-
-            try (BuiltBuffer builtBuffer = bufferBuilder.end()) {
-                this.sunIndexCount = builtBuffer.getDrawParameters().indexCount();
-                this.sunVertexBuffer = RenderSystem.getDevice().createBuffer(() -> "Bedrockify Sun vertex buffer", 8, builtBuffer.getBuffer());
-            }
-        }
-    }
-
-    @WrapOperation(method = "renderCelestialBodies", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/SkyRendering;renderSun(FLnet/minecraft/client/util/math/MatrixStack;)V"))
-    private void bedrockify$modifySunIntensity(SkyRendering instance, float alpha, MatrixStack matrices, Operation<Void> original) {
-        final float intensity = MathHelper.lerp(sunGlareShading.getSunBrightnessDelta(), 1.5f + sunGlareShading.getSunIntensityDelta() * 0.5f, 1.0f);
+    @WrapOperation(method = "renderSun", at = @At(value = "INVOKE", target = "Lorg/joml/Matrix4fStack;scale(FFF)Lorg/joml/Matrix4f;"))
+    private Matrix4f bedrockify$modifySunRadius(Matrix4fStack instance, float x, float y, float z, Operation<Matrix4f> original) {
         final float scale = MathHelper.lerp(sunGlareShading.getSunBrightnessDelta(), 1.3f, 1f);
-
-        // Get model view matrix.
-        Matrix4fStack modelView = RenderSystem.getModelViewStack();
-        modelView.pushMatrix();
-
-        // Get position matrix.
-        Matrix4f position = matrices.peek().getPositionMatrix();
-        // Apply scaling.
-        modelView.mul(position).scale(scale, 1f, scale);
-
-        // Set up texture renderer.
-        TextureManager textureManager = MinecraftClient.getInstance().getTextureManager();
-        AbstractTexture abstractTexture = textureManager.getTexture(getSunTextureId());
-        abstractTexture.setUseMipmaps(false);
-        RenderSystem.ShapeIndexBuffer shapeIndexBuffer = RenderSystem.getSequentialBuffer(VertexFormat.DrawMode.QUADS);
-        GpuBuffer gpuBuffer = shapeIndexBuffer.getIndexBuffer(this.sunIndexCount);
-        GpuTextureView colorView = MinecraftClient.getInstance().getFramebuffer().getColorAttachmentView();
-        GpuTextureView depthView = MinecraftClient.getInstance().getFramebuffer().getDepthAttachmentView();
-        GpuBufferSlice uniform = RenderSystem.getDynamicUniforms().write(modelView, new Vector4f(intensity, intensity, intensity, alpha), new Vector3f(), new Matrix4f(), 0.0F);
-
-        // Draw.
-        try (RenderPass renderPass = RenderSystem.getDevice().createCommandEncoder().createRenderPass(() -> "Bedrockify Sun", colorView, OptionalInt.empty(), depthView, OptionalDouble.empty())) {
-            renderPass.setPipeline(RenderPipelines.POSITION_TEX_COLOR_CELESTIAL);
-            RenderSystem.bindDefaultUniforms(renderPass);
-            renderPass.setUniform("DynamicTransforms", uniform);
-            renderPass.bindSampler("Sampler0", abstractTexture.getGlTextureView());
-            renderPass.setVertexBuffer(0, Objects.requireNonNull(this.sunVertexBuffer));
-            renderPass.setIndexBuffer(gpuBuffer, shapeIndexBuffer.getIndexType());
-            renderPass.drawIndexed(0, 0, this.sunIndexCount, 1);
-        }
-
-        modelView.popMatrix();
+        return original.call(instance, x * scale, y, z * scale);
     }
 
-    @Inject(method = "updateRenderState", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/world/ClientWorld;getSkyColor(Lnet/minecraft/util/math/Vec3d;F)I"))
-    private static void bedrockify$updateSunAngleDiff(ClientWorld world, float f, Vec3d pos, SkyRenderState state, CallbackInfo ci) {
-        final BedrockSunGlareShading sunGlareShading = BedrockifyClient.getInstance().bedrockSunGlareShading;
-        sunGlareShading.updateSunBrightnessDelta(f);
-    }
-
-    @Inject(method = "close", at = @At("HEAD"))
-    private void bedrockify$closeBuffer(CallbackInfo ci) {
-        if (this.sunVertexBuffer != null) {
-            this.sunVertexBuffer.close();
-        }
+    @ModifyExpressionValue(method = "renderSun", at = @At(value = "NEW", target = "org/joml/Vector4f"))
+    private Vector4f bedrockify$modifySunBrightness(Vector4f original) {
+        final float brightness = MathHelper.lerp(sunGlareShading.getSunBrightnessDelta(), 1.5f + sunGlareShading.getSunIntensityDelta() * 0.5f, 1.0f);
+        return original.mul(brightness, brightness, brightness, 1);
     }
 }

--- a/src/main/java/me/juancarloscp52/bedrockify/mixin/client/features/bedrockShading/sunGlare/WorldRendererMixin.java
+++ b/src/main/java/me/juancarloscp52/bedrockify/mixin/client/features/bedrockShading/sunGlare/WorldRendererMixin.java
@@ -1,8 +1,15 @@
 package me.juancarloscp52.bedrockify.mixin.client.features.bedrockShading.sunGlare;
 
+import com.mojang.blaze3d.buffers.GpuBufferSlice;
 import me.juancarloscp52.bedrockify.client.BedrockifyClient;
+import me.juancarloscp52.bedrockify.client.features.bedrockShading.BedrockSunGlareShading;
 import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.render.Camera;
+import net.minecraft.client.render.RenderTickCounter;
 import net.minecraft.client.render.WorldRenderer;
+import net.minecraft.client.util.ObjectAllocator;
+import org.joml.Matrix4f;
+import org.joml.Vector4f;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -23,4 +30,9 @@ public abstract class WorldRendererMixin {
         BedrockifyClient.getInstance().bedrockSunGlareShading.reloadCustomShaderState();
     }
 
+    @Inject(method = "render", at = @At("HEAD"))
+    private static void bedrockify$updateSunAngleDiff(ObjectAllocator allocator, RenderTickCounter tickCounter, boolean renderBlockOutline, Camera camera, Matrix4f positionMatrix, Matrix4f matrix4f, Matrix4f projectionMatrix, GpuBufferSlice fogBuffer, Vector4f fogColor, boolean renderSky, CallbackInfo ci) {
+        final BedrockSunGlareShading sunGlareShading = BedrockifyClient.getInstance().bedrockSunGlareShading;
+        sunGlareShading.updateSunBrightnessDelta(tickCounter.getTickProgress(false));
+    }
 }

--- a/src/main/java/me/juancarloscp52/bedrockify/mixin/client/features/eatingAnimations/PlayerEntityRendererMixin.java
+++ b/src/main/java/me/juancarloscp52/bedrockify/mixin/client/features/eatingAnimations/PlayerEntityRendererMixin.java
@@ -2,10 +2,10 @@ package me.juancarloscp52.bedrockify.mixin.client.features.eatingAnimations;
 
 import me.juancarloscp52.bedrockify.client.BedrockifyClient;
 import me.juancarloscp52.bedrockify.client.features.eatingAnimations.IEatingState;
+import net.minecraft.client.network.ClientPlayerLikeEntity;
 import net.minecraft.client.render.entity.PlayerEntityRenderer;
-import net.minecraft.client.render.entity.state.LivingEntityRenderState;
 import net.minecraft.client.render.entity.state.PlayerEntityRenderState;
-import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.PlayerLikeEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.consume.UseAction;
 import net.minecraft.util.Hand;
@@ -16,18 +16,18 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(PlayerEntityRenderer.class)
-public abstract class PlayerEntityRendererMixin {
-    @Inject(method = "updateRenderState(Lnet/minecraft/entity/LivingEntity;Lnet/minecraft/client/render/entity/state/LivingEntityRenderState;F)V", at = @At("HEAD"))
-    private void bedrockify$storeEatingState(LivingEntity livingEntity, LivingEntityRenderState livingEntityRenderState, float f, CallbackInfo ci) {
-        if (!BedrockifyClient.getInstance().settings.isEatingAnimationsEnabled() || !(livingEntityRenderState instanceof IEatingState state)) {
+public abstract class PlayerEntityRendererMixin<AvatarlikeEntity extends PlayerLikeEntity & ClientPlayerLikeEntity> {
+    @Inject(method = "updateRenderState", at = @At("HEAD"))
+    private void bedrockify$storeEatingState(AvatarlikeEntity avatarlikeEntity, PlayerEntityRenderState playerEntityRenderState, float f, CallbackInfo ci) {
+        if (!BedrockifyClient.getInstance().settings.isEatingAnimationsEnabled() || !(playerEntityRenderState instanceof IEatingState state)) {
             return;
         }
 
-        ItemStack mainHandStack = livingEntity.getMainHandStack();
-        ItemStack offHandStack = livingEntity.getOffHandStack();
-        if (bedrockify$checkEatingAction(livingEntityRenderState, Hand.MAIN_HAND, mainHandStack)) {
+        ItemStack mainHandStack = avatarlikeEntity.getMainHandStack();
+        ItemStack offHandStack = avatarlikeEntity.getOffHandStack();
+        if (bedrockify$checkEatingAction(avatarlikeEntity, playerEntityRenderState, Hand.MAIN_HAND, mainHandStack)) {
             state.setEatingHand(Hand.MAIN_HAND);
-        } else if (bedrockify$checkEatingAction(livingEntityRenderState, Hand.OFF_HAND, offHandStack)) {
+        } else if (bedrockify$checkEatingAction(avatarlikeEntity, playerEntityRenderState, Hand.OFF_HAND, offHandStack)) {
             state.setEatingHand(Hand.OFF_HAND);
         } else {
             state.setEatingHand(null);
@@ -35,8 +35,7 @@ public abstract class PlayerEntityRendererMixin {
     }
 
     @Unique
-    private boolean bedrockify$checkEatingAction(LivingEntityRenderState state, Hand hand, ItemStack itemStack) {
-        PlayerEntityRenderState playerState = (PlayerEntityRenderState) state;
-        return playerState.itemUseTime > 0 && playerState.activeHand == hand && (itemStack.getUseAction() == UseAction.EAT || itemStack.getUseAction() == UseAction.DRINK);
+    private boolean bedrockify$checkEatingAction(AvatarlikeEntity entity, PlayerEntityRenderState state, Hand hand, ItemStack itemStack) {
+        return entity.isUsingItem() && state.activeHand == hand && (itemStack.getUseAction() == UseAction.EAT || itemStack.getUseAction() == UseAction.DRINK);
     }
 }

--- a/src/main/java/me/juancarloscp52/bedrockify/mixin/client/features/fishingBobber/FishingBobberEntityRendererMixin.java
+++ b/src/main/java/me/juancarloscp52/bedrockify/mixin/client/features/fishingBobber/FishingBobberEntityRendererMixin.java
@@ -4,14 +4,12 @@ import me.juancarloscp52.bedrockify.client.BedrockifyClient;
 import me.juancarloscp52.bedrockify.client.features.fishingBobber.FishingBobber3DModel;
 import net.minecraft.client.model.Model;
 import net.minecraft.client.render.OverlayTexture;
-import net.minecraft.client.render.VertexConsumer;
 import net.minecraft.client.render.command.OrderedRenderCommandQueue;
 import net.minecraft.client.render.entity.EntityRendererFactory;
 import net.minecraft.client.render.entity.FishingBobberEntityRenderer;
 import net.minecraft.client.render.entity.state.FishingBobberEntityState;
 import net.minecraft.client.render.state.CameraRenderState;
 import net.minecraft.client.util.math.MatrixStack;
-import net.minecraft.util.Colors;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
@@ -21,7 +19,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @Mixin(FishingBobberEntityRenderer.class)
 public abstract class FishingBobberEntityRendererMixin {
     @Unique
-    private Model bobberModel;
+    private Model<FishingBobberEntityState> bobberModel;
 
     @Inject(method = "<init>", at = @At("RETURN"))
     private void bedrockify$injectCtor(EntityRendererFactory.Context context, CallbackInfo ci) {
@@ -29,7 +27,7 @@ public abstract class FishingBobberEntityRendererMixin {
     }
 
     @Inject(method = "vertex", at = @At("HEAD"), cancellable = true)
-    private static void bedrockify$cancelOriginalBobberRendering(VertexConsumer buffer, MatrixStack.Entry matrix, int light, float x, int y, int u, int v, CallbackInfo ci) {
+    private static void bedrockify$cancelOriginalBobberRendering(CallbackInfo ci) {
         if (!BedrockifyClient.getInstance().settings.fishingBobber3D) {
             return;
         }
@@ -37,7 +35,7 @@ public abstract class FishingBobberEntityRendererMixin {
         ci.cancel();
     }
 
-    @Inject(method = "render(Lnet/minecraft/client/render/entity/state/FishingBobberEntityState;Lnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/client/render/command/OrderedRenderCommandQueue;Lnet/minecraft/client/render/state/CameraRenderState;)V", at = @At("RETURN"))
+    @Inject(method = "render", at = @At("RETURN"))
     private void bedrockify$render3DBobber(FishingBobberEntityState fishingBobberEntityState, MatrixStack matrixStack, OrderedRenderCommandQueue orderedRenderCommandQueue, CameraRenderState cameraRenderState, CallbackInfo ci) {
         if (!BedrockifyClient.getInstance().settings.fishingBobber3D) {
             return;
@@ -45,8 +43,7 @@ public abstract class FishingBobberEntityRendererMixin {
 
         matrixStack.push();
         matrixStack.translate(0f, -0.0075f, 0f);
-        //TODO: is white/ too bright
-        orderedRenderCommandQueue.submitModel(bobberModel, fishingBobberEntityState, matrixStack, FishingBobber3DModel.RENDER_LAYER, fishingBobberEntityState.light, OverlayTexture.DEFAULT_UV, Colors.WHITE, null);
+        orderedRenderCommandQueue.submitModel(this.bobberModel, fishingBobberEntityState, matrixStack, FishingBobber3DModel.RENDER_LAYER, fishingBobberEntityState.light, OverlayTexture.DEFAULT_UV, fishingBobberEntityState.outlineColor, null);
         matrixStack.pop();
     }
 }

--- a/src/main/java/me/juancarloscp52/bedrockify/mixin/client/features/idleHandAnimations/HeldItemRendererMixin.java
+++ b/src/main/java/me/juancarloscp52/bedrockify/mixin/client/features/idleHandAnimations/HeldItemRendererMixin.java
@@ -2,8 +2,6 @@ package me.juancarloscp52.bedrockify.mixin.client.features.idleHandAnimations;
 
 import me.juancarloscp52.bedrockify.client.BedrockifyClient;
 import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.network.ClientPlayerEntity;
-import net.minecraft.client.render.command.OrderedRenderCommandQueue;
 import net.minecraft.client.render.item.HeldItemRenderer;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.util.Arm;
@@ -23,7 +21,7 @@ public class HeldItemRendererMixin {
     private static final double ONE_CYCLE = 2 * Math.PI;
 
     @Inject(method = "renderItem(FLnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/client/render/command/OrderedRenderCommandQueue;Lnet/minecraft/client/network/ClientPlayerEntity;I)V", at = @At("HEAD"))
-    private void bedrockify$updateSwayDelta(float tickProgress, MatrixStack matrices, OrderedRenderCommandQueue orderedRenderCommandQueue, ClientPlayerEntity player, int light, CallbackInfo ci) {
+    private void bedrockify$updateSwayDelta(CallbackInfo ci) {
         if (MinecraftClient.getInstance().isPaused()) {
             return;
         }

--- a/src/main/java/me/juancarloscp52/bedrockify/mixin/client/features/loadingScreens/LevelLoadingScreenMixin.java
+++ b/src/main/java/me/juancarloscp52/bedrockify/mixin/client/features/loadingScreens/LevelLoadingScreenMixin.java
@@ -8,6 +8,7 @@ import net.minecraft.client.gui.screen.world.LevelLoadingScreen;
 import net.minecraft.client.world.ClientChunkLoadProgress;
 import net.minecraft.text.Text;
 import net.minecraft.util.Util;
+import net.minecraft.util.math.MathHelper;
 import net.minecraft.world.chunk.ChunkLoadMap;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
@@ -36,7 +37,8 @@ public abstract class LevelLoadingScreenMixin extends Screen {
 
         int xPosition = this.width / 2;
         int yPosition = this.height / 2;
-        LoadingScreenWidget.getInstance().render(context, xPosition, yPosition, Text.translatable("narrator.loading", Text.translatable("loading.progress", (this.chunkLoadProgress.getLoadProgress()*100.0F)).getString()), null, (int)(this.chunkLoadProgress.getLoadProgress()*100.0F));
+        int loadPercent = MathHelper.ceil(this.chunkLoadProgress.getLoadProgress() * 100);
+        LoadingScreenWidget.getInstance().render(context, xPosition, yPosition, Text.translatable("narrator.loading", Text.translatable("loading.progress", loadPercent).getString()), null, loadPercent);
 
         long l = Util.getMeasuringTimeMs();
         if (l - this.lastNarrationTime > 2000L) {

--- a/src/main/java/me/juancarloscp52/bedrockify/mixin/common/features/animalEatingParticles/AnimalEntityMixin.java
+++ b/src/main/java/me/juancarloscp52/bedrockify/mixin/common/features/animalEatingParticles/AnimalEntityMixin.java
@@ -2,20 +2,16 @@ package me.juancarloscp52.bedrockify.mixin.common.features.animalEatingParticles
 
 import me.juancarloscp52.bedrockify.common.features.animalEatingParticles.EatingParticlesUtil;
 import net.minecraft.entity.passive.AnimalEntity;
-import net.minecraft.entity.passive.AxolotlEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
-import net.minecraft.item.Items;
 import net.minecraft.util.Hand;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-@Mixin(AxolotlEntity.class)
-public class AxolotlEntityMixin extends ExtendMobEntityMixin {
+@Mixin(AnimalEntity.class)
+public class AnimalEntityMixin extends ExtendMobEntityMixin {
     @Override
     protected void bedrockify$mobEat_AtHead(PlayerEntity player, Hand hand, ItemStack stack, CallbackInfo ci) {
-        if (stack.isOf(Items.TROPICAL_FISH_BUCKET)) {
-            EatingParticlesUtil.spawnItemParticles(player, new ItemStack(Items.TROPICAL_FISH), AnimalEntity.class.cast(this));
-        }
+        EatingParticlesUtil.spawnItemParticles(player, stack, AnimalEntity.class.cast(this));
     }
 }

--- a/src/main/java/me/juancarloscp52/bedrockify/mixin/common/features/animalEatingParticles/ExtendMobEntityMixin.java
+++ b/src/main/java/me/juancarloscp52/bedrockify/mixin/common/features/animalEatingParticles/ExtendMobEntityMixin.java
@@ -1,8 +1,6 @@
 package me.juancarloscp52.bedrockify.mixin.common.features.animalEatingParticles;
 
-import me.juancarloscp52.bedrockify.common.features.animalEatingParticles.EatingParticlesUtil;
 import net.minecraft.entity.mob.MobEntity;
-import net.minecraft.entity.passive.AnimalEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.Hand;
@@ -12,12 +10,9 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(MobEntity.class)
-public class MobEntityMixin {
-
-    @Inject(method = "eat", at=@At("HEAD"))
-    public void spawnEatingParticles(PlayerEntity player, Hand hand, ItemStack stack, CallbackInfo ci){
-        EatingParticlesUtil.spawnItemParticles(player, stack, ((AnimalEntity)(Object)this));
+public abstract class ExtendMobEntityMixin {
+    @Inject(method = "eat", at = @At("HEAD"), cancellable = true)
+    protected void bedrockify$mobEat_AtHead(PlayerEntity player, Hand hand, ItemStack stack, CallbackInfo ci) {
+        // an empty body for overridable injection point
     }
-
-
 }

--- a/src/main/java/me/juancarloscp52/bedrockify/mixin/common/features/fireAspect/CampfireBlockMixin.java
+++ b/src/main/java/me/juancarloscp52/bedrockify/mixin/common/features/fireAspect/CampfireBlockMixin.java
@@ -6,7 +6,6 @@ import me.juancarloscp52.bedrockify.common.features.fireAspectLight.FireAspectLi
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.CampfireBlock;
-import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.sound.SoundCategory;

--- a/src/main/java/me/juancarloscp52/bedrockify/mixin/common/features/fireAspect/CandleBlockMixin.java
+++ b/src/main/java/me/juancarloscp52/bedrockify/mixin/common/features/fireAspect/CandleBlockMixin.java
@@ -6,7 +6,6 @@ import me.juancarloscp52.bedrockify.common.features.fireAspectLight.FireAspectLi
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.CandleBlock;
-import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.sound.SoundCategory;

--- a/src/main/java/me/juancarloscp52/bedrockify/mixin/common/features/fireAspect/CandleCakeBlockMixin.java
+++ b/src/main/java/me/juancarloscp52/bedrockify/mixin/common/features/fireAspect/CandleCakeBlockMixin.java
@@ -6,7 +6,6 @@ import me.juancarloscp52.bedrockify.common.features.fireAspectLight.FireAspectLi
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.CandleCakeBlock;
-import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.sound.SoundCategory;

--- a/src/main/java/me/juancarloscp52/bedrockify/mixin/common/features/fireAspect/PlayerEntityMixin.java
+++ b/src/main/java/me/juancarloscp52/bedrockify/mixin/common/features/fireAspect/PlayerEntityMixin.java
@@ -4,7 +4,6 @@ import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 import me.juancarloscp52.bedrockify.Bedrockify;
 import me.juancarloscp52.bedrockify.common.features.fireAspectLight.FireAspectLightHelper;
 import net.minecraft.entity.Entity;
-import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.entity.vehicle.TntMinecartEntity;
 import net.minecraft.item.ItemStack;

--- a/src/main/java/me/juancarloscp52/bedrockify/mixin/common/features/fireAspect/TntBlockMixin.java
+++ b/src/main/java/me/juancarloscp52/bedrockify/mixin/common/features/fireAspect/TntBlockMixin.java
@@ -7,7 +7,6 @@ import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.Blocks;
 import net.minecraft.block.TntBlock;
-import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.sound.SoundCategory;

--- a/src/main/resources/bedrockify.mixins.json
+++ b/src/main/resources/bedrockify.mixins.json
@@ -58,8 +58,9 @@
   ],
   "mixins": [
     "common.features.animalEatingParticles.AxolotlEntityMixin",
+    "common.features.animalEatingParticles.ExtendMobEntityMixin",
     "common.features.animalEatingParticles.HorseEntityMixin",
-    "common.features.animalEatingParticles.MobEntityMixin",
+    "common.features.animalEatingParticles.AnimalEntityMixin",
     "common.features.animalEatingParticles.WolfEntityMixin",
     "common.features.cauldron.ArmorDyeRecipeMixin",
     "common.features.cauldron.CauldronBehaviorMixin",


### PR DESCRIPTION
Hi! Thank you for porting to 1.21.6 and resolving HudOpacity issue.
I already have some codes for 1.21.9 with testing, so I tried to port it over without breaking the HudOpacity functionality.
I hope this commit proves useful.

----
**Changes**

fixes:
- Eating Animations
- Level Loading screen (loading progress percentage)
- Rendering issue in fishing bobber 3D model

optimizes:
- Rendering the Sun

and rearranges/optimizes mixins:
- (New) ExtendMobEntityMixin
- MobEntityMixin -> AnimalEntityMixin