### PR TITLE
Support Bedrock-like Cube Map Rendering functionality

### DIFF
--- a/src/main/java/me/juancarloscp52/bedrockify/client/BedrockifyClientSettings.java
+++ b/src/main/java/me/juancarloscp52/bedrockify/client/BedrockifyClientSettings.java
@@ -56,6 +56,7 @@ public class BedrockifyClientSettings {
     public boolean hideEditionBranding = false;
     public boolean hotBarOverhang = true;
     public boolean babyVillagerHeads = true;
+    public boolean bedrockCubeMap = false;
 
     public boolean isPickupAnimationsEnabled() {
         return pickupAnimations;

--- a/src/main/java/me/juancarloscp52/bedrockify/client/gui/SettingsGUI.java
+++ b/src/main/java/me/juancarloscp52/bedrockify/client/gui/SettingsGUI.java
@@ -122,6 +122,7 @@ public class SettingsGUI {
             }).build());
             gui.addEntry(entryBuilder.startEnumSelector(Text.translatable("bedrockify.options.showBedrockIfyButton"), BedrockifyClientSettings.ButtonPosition.class, settingsClient.bedrockIfyButtonPosition).setTooltip(wrapLines(Text.translatable("bedrockify.options.showBedrockIfyButton.tooltip"))).setEnumNameProvider(anEnum -> Text.translatable(((BedrockifyClientSettings.ButtonPosition)anEnum).text)).setDefaultValue(BedrockifyClientSettings.ButtonPosition.BELOW_SLIDERS).setSaveConsumer(buttonPosition -> settingsClient.bedrockIfyButtonPosition =buttonPosition).build());
             gui.addEntry(entryBuilder.startBooleanToggle(Text.translatable("bedrockify.options.editionBranding"), settingsClient.hideEditionBranding).setDefaultValue(false).setSaveConsumer(newValue -> settingsClient.hideEditionBranding =newValue).build());
+            gui.addEntry(entryBuilder.startBooleanToggle(Text.translatable("bedrockify.options.bedrockCubeMap"), settingsClient.bedrockCubeMap).setDefaultValue(false).setSaveConsumer(newValue -> settingsClient.bedrockCubeMap = newValue).build());
 
 
         /*

--- a/src/main/java/me/juancarloscp52/bedrockify/mixin/client/features/bedrockCubeMap/RotatingCubeMapRendererMixin.java
+++ b/src/main/java/me/juancarloscp52/bedrockify/mixin/client/features/bedrockCubeMap/RotatingCubeMapRendererMixin.java
@@ -1,0 +1,22 @@
+package me.juancarloscp52.bedrockify.mixin.client.features.bedrockCubeMap;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import me.juancarloscp52.bedrockify.client.BedrockifyClient;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.CubeMapRenderer;
+import net.minecraft.client.gui.RotatingCubeMapRenderer;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+@Mixin(RotatingCubeMapRenderer.class)
+public abstract class RotatingCubeMapRendererMixin {
+    @WrapOperation(method = "render", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/CubeMapRenderer;draw(Lnet/minecraft/client/MinecraftClient;FF)V"))
+    private void bedrockify$onCubeMapRender(CubeMapRenderer instance, MinecraftClient client, float x, float y, Operation<Void> original) {
+        if (BedrockifyClient.getInstance().settings.bedrockCubeMap) {
+            original.call(instance, client, x, -y);
+        } else {
+            original.call(instance, client, x, y);
+        }
+    }
+}

--- a/src/main/java/me/juancarloscp52/bedrockify/mixin/client/features/idleHandAnimations/HeldItemRendererMixin.java
+++ b/src/main/java/me/juancarloscp52/bedrockify/mixin/client/features/idleHandAnimations/HeldItemRendererMixin.java
@@ -18,7 +18,7 @@ public class HeldItemRendererMixin {
     @Unique
     float timer = 0;
     @Unique
-    private static final double ONE_CYCLE = 2 * Math.PI;
+    private static final float ONE_CYCLE = 2 * MathHelper.PI;
 
     @Inject(method = "renderItem(FLnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/client/render/command/OrderedRenderCommandQueue;Lnet/minecraft/client/network/ClientPlayerEntity;I)V", at = @At("HEAD"))
     private void bedrockify$updateSwayDelta(CallbackInfo ci) {
@@ -28,7 +28,7 @@ public class HeldItemRendererMixin {
         timer += BedrockifyClient.getInstance().deltaTime * 0.000000002f;
         if (timer > ONE_CYCLE) {
             // Prevents float overflow
-            timer = (float) MathHelper.floorMod(timer, ONE_CYCLE);
+            timer -= ONE_CYCLE;
         }
     }
 

--- a/src/main/java/me/juancarloscp52/bedrockify/mixin/featureManager/MixinFeatureManager.java
+++ b/src/main/java/me/juancarloscp52/bedrockify/mixin/featureManager/MixinFeatureManager.java
@@ -21,6 +21,7 @@ public class MixinFeatureManager {
         features.put("client.core.clientRenderTimer", true);
         features.put("client.core.bedrockIfyButton", true);
         features.put("client.features.chat", true);
+        features.put("client.features.bedrockCubeMap",true);
         features.put("client.features.eatingAnimations", true);
         features.put("client.features.fishingBobber", true);
         features.put("client.features.heldItemTooltips",true);

--- a/src/main/resources/assets/bedrockify/lang/en_us.json
+++ b/src/main/resources/assets/bedrockify/lang/en_us.json
@@ -41,6 +41,7 @@
   "bedrockify.options.chatStyle.bedrock": "Bedrock",
   "bedrockify.options.chatStyle.vanilla": "Java",
   "bedrockify.options.editionBranding": "Hide Edition Branding:",
+  "bedrockify.options.bedrockCubeMap": "Bedrock-like Cube Map Rendering:",
   "bedrockify.options.tooltips": "Item Tooltips:",
   "bedrockify.options.tooltips.background": "Tooltips Background Opacity:",
   "bedrockify.options.inventoryHighlight": "Inventory Item Slot Highlight:",

--- a/src/main/resources/assets/bedrockify/lang/en_us.json
+++ b/src/main/resources/assets/bedrockify/lang/en_us.json
@@ -41,7 +41,7 @@
   "bedrockify.options.chatStyle.bedrock": "Bedrock",
   "bedrockify.options.chatStyle.vanilla": "Java",
   "bedrockify.options.editionBranding": "Hide Edition Branding:",
-  "bedrockify.options.bedrockCubeMap": "Bedrock-like Cube Map Rendering:",
+  "bedrockify.options.bedrockCubeMap": "Bedrock-like Panorama Screen:",
   "bedrockify.options.tooltips": "Item Tooltips:",
   "bedrockify.options.tooltips.background": "Tooltips Background Opacity:",
   "bedrockify.options.inventoryHighlight": "Inventory Item Slot Highlight:",

--- a/src/main/resources/assets/bedrockify/lang/es_ar.json
+++ b/src/main/resources/assets/bedrockify/lang/es_ar.json
@@ -40,6 +40,7 @@
   "bedrockify.options.chatStyle.bedrock": "Bedrock",
   "bedrockify.options.chatStyle.vanilla": "Vanilla",
   "bedrockify.options.editionBranding": "Ocultar logo de edición:",
+  "bedrockify.options.bedrockCubeMap": "Usar cubemap al estilo bedrock:",
   "bedrockify.options.tooltips": "Descripción de ítems:",
   "bedrockify.options.tooltips.background": "Opacidad del fondo de descripciones:",
   "bedrockify.options.inventoryHighlight": "Resalto de slot en inventario:",

--- a/src/main/resources/assets/bedrockify/lang/es_cl.json
+++ b/src/main/resources/assets/bedrockify/lang/es_cl.json
@@ -40,6 +40,7 @@
   "bedrockify.options.chatStyle.bedrock": "Bedrock",
   "bedrockify.options.chatStyle.vanilla": "Vanilla",
   "bedrockify.options.editionBranding": "Ocultar logo de edición:",
+  "bedrockify.options.bedrockCubeMap": "Usar cubemap al estilo bedrock:",
   "bedrockify.options.tooltips": "Descripción de ítems:",
   "bedrockify.options.tooltips.background": "Opacidad del fondo de descripciones:",
   "bedrockify.options.inventoryHighlight": "Resalto de slot en inventario:",

--- a/src/main/resources/assets/bedrockify/lang/es_ec.json
+++ b/src/main/resources/assets/bedrockify/lang/es_ec.json
@@ -40,6 +40,7 @@
   "bedrockify.options.chatStyle.bedrock": "Bedrock",
   "bedrockify.options.chatStyle.vanilla": "Vanilla",
   "bedrockify.options.editionBranding": "Ocultar logo de edición:",
+  "bedrockify.options.bedrockCubeMap": "Usar cubemap al estilo bedrock:",
   "bedrockify.options.tooltips": "Descripción de ítems:",
   "bedrockify.options.tooltips.background": "Opacidad del fondo de descripciones:",
   "bedrockify.options.inventoryHighlight": "Resalto de slot en inventario:",

--- a/src/main/resources/assets/bedrockify/lang/es_es.json
+++ b/src/main/resources/assets/bedrockify/lang/es_es.json
@@ -40,6 +40,7 @@
   "bedrockify.options.chatStyle.bedrock": "Bedrock",
   "bedrockify.options.chatStyle.vanilla": "Vanilla",
   "bedrockify.options.editionBranding": "Ocultar logo de edición:",
+  "bedrockify.options.bedrockCubeMap": "Usar cubemap al estilo bedrock:",
   "bedrockify.options.tooltips": "Descripción de ítems:",
   "bedrockify.options.tooltips.background": "Opacidad del fondo de descripciones:",
   "bedrockify.options.inventoryHighlight": "Resalto de slot en inventario:",

--- a/src/main/resources/assets/bedrockify/lang/es_mx.json
+++ b/src/main/resources/assets/bedrockify/lang/es_mx.json
@@ -40,6 +40,7 @@
   "bedrockify.options.chatStyle.bedrock": "Bedrock",
   "bedrockify.options.chatStyle.vanilla": "Vanilla",
   "bedrockify.options.editionBranding": "Ocultar logo de edición:",
+  "bedrockify.options.bedrockCubeMap": "Usar cubemap al estilo bedrock:",
   "bedrockify.options.tooltips": "Descripción de ítems:",
   "bedrockify.options.tooltips.background": "Opacidad del fondo de descripciones:",
   "bedrockify.options.inventoryHighlight": "Resalto de slot en inventario:",

--- a/src/main/resources/assets/bedrockify/lang/es_uy.json
+++ b/src/main/resources/assets/bedrockify/lang/es_uy.json
@@ -40,6 +40,7 @@
   "bedrockify.options.chatStyle.bedrock": "Bedrock",
   "bedrockify.options.chatStyle.vanilla": "Vanilla",
   "bedrockify.options.editionBranding": "Ocultar logo de edición:",
+  "bedrockify.options.bedrockCubeMap": "Usar cubemap al estilo bedrock:",
   "bedrockify.options.tooltips": "Descripción de ítems:",
   "bedrockify.options.tooltips.background": "Opacidad del fondo de descripciones:",
   "bedrockify.options.inventoryHighlight": "Resalto de slot en inventario:",

--- a/src/main/resources/assets/bedrockify/lang/es_ve.json
+++ b/src/main/resources/assets/bedrockify/lang/es_ve.json
@@ -40,6 +40,7 @@
   "bedrockify.options.chatStyle.bedrock": "Bedrock",
   "bedrockify.options.chatStyle.vanilla": "Vanilla",
   "bedrockify.options.editionBranding": "Ocultar logo de edición:",
+  "bedrockify.options.bedrockCubeMap": "Usar cubemap al estilo bedrock:",
   "bedrockify.options.tooltips": "Descripción de ítems:",
   "bedrockify.options.tooltips.background": "Opacidad del fondo de descripciones:",
   "bedrockify.options.inventoryHighlight": "Resalto de slot en inventario:",

--- a/src/main/resources/bedrockify.mixins.json
+++ b/src/main/resources/bedrockify.mixins.json
@@ -14,6 +14,7 @@
     "client.features.bedrockShading.sunGlare.CloudRendererMixin",
     "client.features.bedrockShading.sunGlare.SkyRenderingMixin",
     "client.features.bedrockShading.sunGlare.WorldRendererMixin",
+    "client.features.bedrockCubeMap.RotatingCubeMapRendererMixin",
     "client.features.biggerDraggingItem.HandledScreenMixin",
     "client.features.chat.ChatHudMixin",
     "client.features.eatingAnimations.PlayerEntityModelMixin",


### PR DESCRIPTION
resolve #432

Add bedrockCubeMap option under GUI -> Hide Edition Branding.

While looking at Vanilla’s cube map rendering code, I found some lines that seemed useful for the idleHandAnimations functionality, so I took the opportunity to make a few minor fixes.
Included into mixin/client/features/idleHandAnimations/HeldItemRendererMixin.java