### PR TITLE
Fix opacity of item stack count in hotbar

### DIFF
--- a/src/main/java/me/juancarloscp52/bedrockify/mixin/client/features/hudOpacity/GuiGraphicsAccessor.java
+++ b/src/main/java/me/juancarloscp52/bedrockify/mixin/client/features/hudOpacity/GuiGraphicsAccessor.java
@@ -1,0 +1,15 @@
+package me.juancarloscp52.bedrockify.mixin.client.features.hudOpacity;
+
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.world.item.ItemStack;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Invoker;
+
+@Mixin(GuiGraphics.class)
+public interface GuiGraphicsAccessor {
+    @Invoker("renderItemBar")
+    void invokeRenderItemBar(ItemStack itemStack, int x, int y);
+
+    @Invoker("renderItemCooldown")
+    void invokeRenderItemCooldown(ItemStack itemStack, int x, int y);
+}

--- a/src/main/java/me/juancarloscp52/bedrockify/mixin/client/features/hudOpacity/GuiMixin.java
+++ b/src/main/java/me/juancarloscp52/bedrockify/mixin/client/features/hudOpacity/GuiMixin.java
@@ -6,10 +6,12 @@ import com.mojang.blaze3d.pipeline.RenderPipeline;
 import me.juancarloscp52.bedrockify.client.BedrockifyClient;
 import me.juancarloscp52.bedrockify.client.features.hudOpacity.HudOpacity;
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.Font;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.Gui;
 import net.minecraft.resources.Identifier;
 import net.minecraft.util.ARGB;
+import net.minecraft.world.item.ItemStack;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
@@ -37,6 +39,20 @@ public class GuiMixin {
     @WrapOperation(method = "renderItemHotbar", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/GuiGraphics;blitSprite(Lcom/mojang/blaze3d/pipeline/RenderPipeline;Lnet/minecraft/resources/Identifier;IIIIIIII)V"))
     public void setAttackIconColorOpacity(GuiGraphics instance, RenderPipeline pipeline, Identifier sprite, int textureWidth, int textureHeight, int u, int v, int x, int y, int width, int height, Operation<Void> original){
         instance.blitSprite(pipeline, sprite, textureWidth, textureHeight, u, v, x, y, width, height, ARGB.white(hudOpacity.getHudOpacity(false)));
+    }
+
+    @WrapOperation(method = "renderSlot", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/GuiGraphics;renderItemDecorations(Lnet/minecraft/client/gui/Font;Lnet/minecraft/world/item/ItemStack;II)V"))
+    private void bedrockify$applyOpacityToStackCount(GuiGraphics instance, Font font, ItemStack itemStack, int x, int y, Operation<Void> original) {
+        if (!itemStack.isEmpty() && instance instanceof GuiGraphicsAccessor accessor) {
+            instance.pose().pushMatrix();
+            accessor.invokeRenderItemBar(itemStack, x, y);
+            accessor.invokeRenderItemCooldown(itemStack, x, y);
+            if (itemStack.getCount() != 1) {
+                String stackCount = String.valueOf(itemStack.getCount());
+                instance.drawString(font, stackCount, x + 19 - 2 - font.width(stackCount), y + 6 + 3, ARGB.white(hudOpacity.getHudOpacity(false)), true);
+            }
+            instance.pose().popMatrix();
+        }
     }
 
     //region Status Bars

--- a/src/main/resources/bedrockify.mixins.json
+++ b/src/main/resources/bedrockify.mixins.json
@@ -24,6 +24,7 @@
     "client.features.fishingBobber.FishingBobberEntityRendererMixin",
     "client.features.heldItemTooltips.ItemTooltipsMixin",
     "client.features.hudOpacity.BossBarHudMixin",
+    "client.features.hudOpacity.GuiGraphicsAccessor",
     "client.features.hudOpacity.ExperienceBarMixin",
     "client.features.hudOpacity.GuiRendererMixin",
     "client.features.hudOpacity.InGameHudMixin",


### PR DESCRIPTION
resolve #440

Text opacity of item stack count in Hotbar follows HudOpacity setting.

Ported the code that worked with Yarn to official Mojmap. Still in draft until launch and functional verification are completed.

> [!NOTE]
> The class `GuiGraphics` has been renamed to `GuiGraphicsExtractor` since 26.1-pre.1.