### PR TITLE
Support custom item name in HeldItemTooltips

### DIFF
--- a/src/main/java/me/juancarloscp52/bedrockify/client/features/heldItemTooltips/tooltip/ContainerTooltip.java
+++ b/src/main/java/me/juancarloscp52/bedrockify/client/features/heldItemTooltips/tooltip/ContainerTooltip.java
@@ -1,23 +1,16 @@
 package me.juancarloscp52.bedrockify.client.features.heldItemTooltips.tooltip;
 
-import net.minecraft.world.item.Item;
-import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.PotionItem;
-import net.minecraft.network.chat.MutableComponent;
+import net.minecraft.core.component.DataComponents;
 import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.MutableComponent;
+import net.minecraft.world.item.ItemStack;
 
 public class ContainerTooltip extends Tooltip {
     Component itemName;
 
     public ContainerTooltip(ItemStack itemStack){
         this.primaryValue = itemStack.getCount();
-
-        Item item = itemStack.getItem();
-        if (item instanceof PotionItem potionItem) {
-            this.itemName = potionItem.getName(itemStack);
-        } else {
-            this.itemName = Component.translatable(item.getDescriptionId());
-        }
+        this.itemName = itemStack.getOrDefault(DataComponents.CUSTOM_NAME, itemStack.getItemName());
     }
 
     @Override


### PR DESCRIPTION
Allows to show the custom item name in HeldItemTooltips functionality.
This applies to items that have container components (such as Shulker boxes and Bundles).

---

**Changes**

* client/features/heldItemTooltips/tooltip/ContainerTooltip.java
  - Store the CUSTOM_NAME component if exists, otherwise the item name of the stack.