### PR TITLE
Fix rebuilding widgets on OptionsScreen

### DIFF
--- a/src/main/java/me/juancarloscp52/bedrockify/mixin/client/core/bedrockIfyButton/ExtendScreenMixin.java
+++ b/src/main/java/me/juancarloscp52/bedrockify/mixin/client/core/bedrockIfyButton/ExtendScreenMixin.java
@@ -27,8 +27,8 @@ public abstract class ExtendScreenMixin {
     @Shadow
     protected abstract <T extends GuiEventListener & Renderable & NarratableEntry> T addRenderableWidget(final T widget);
 
-    @Inject(method = "added", at = @At("HEAD"))
-    protected void bedrockify$injectAdded_AtHead(CallbackInfo ci) {
+    @Inject(method = "init(II)V", at = @At("TAIL"))
+    protected void bedrockify$added(CallbackInfo ci) {
         // Empty body for overridable method.
     }
 }

--- a/src/main/java/me/juancarloscp52/bedrockify/mixin/client/core/bedrockIfyButton/OptionsScreenMixin.java
+++ b/src/main/java/me/juancarloscp52/bedrockify/mixin/client/core/bedrockIfyButton/OptionsScreenMixin.java
@@ -47,11 +47,11 @@ public abstract class OptionsScreenMixin extends ExtendScreenMixin {
     }
 
     @Override
-    protected void bedrockify$injectAdded_AtHead(CallbackInfo ci) {
-        super.bedrockify$injectAdded_AtHead(ci);
+    protected void bedrockify$added(CallbackInfo ci) {
+        super.bedrockify$added(ci);
 
-        // Hide current widgets.
-        this.layout.visitChildren(element -> element.visitWidgets(widget -> widget.visible = false));
+        // Remove current widgets.
+        this.layout.removeChildren();
 
         // Execute Screen#clearWidgets and then OptionsScreen#init
         this.rebuildWidgets();


### PR DESCRIPTION
resolve #464 

The original `Screen#added` method is no longer called, injects Bedrockify’s custom code instead.

---

**Changes**

* Injection point has been changed:
  - `added()V` -> `init(II)V`